### PR TITLE
Fix mutable default lists in form models

### DIFF
--- a/src/survaize/cspro/form.py
+++ b/src/survaize/cspro/form.py
@@ -27,7 +27,7 @@ class FormItemBase(FormBase):
 class FormGroup(FormItemBase):
     required: bool
     max: int
-    items: list[FormItemBase] = []
+    items: list[FormItemBase] = Field(default_factory=list)
 
 
 class FormText(FormItemBase):
@@ -64,7 +64,7 @@ class FormField(FormItemBase):
 class RosterColumn(BaseModel):
     width: int | None = None
     header_text: FormText | None = None
-    fields: list[FormField] = []
+    fields: list[FormField] = Field(default_factory=list)
 
 
 class Roster(FormGroup):
@@ -76,8 +76,8 @@ class Roster(FormGroup):
     heading_row_height: int
     use_occurrence_labels: bool | None = None
     free_movement: bool = False
-    columns: list[RosterColumn] = []
-    stub_text: list[FormText] = []
+    columns: list[RosterColumn] = Field(default_factory=list)
+    stub_text: list[FormText] = Field(default_factory=list)
 
 
 class FormLevel(FormBase):
@@ -87,7 +87,7 @@ class FormLevel(FormBase):
 class Form(FormBase):
     level: int
     size: tuple[int, int]
-    items: list[FormItemBase] = []
+    items: list[FormItemBase] = Field(default_factory=list)
 
 
 class FormFile(BaseModel):


### PR DESCRIPTION
## Summary
- avoid shared mutable defaults in CSPro form data models by using `Field(default_factory=list)`

## Testing
- `ruff check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6845a65560b0832091df76e95a93c565