### PR TITLE
Fix PyPI reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Survaize is a tool that automatically converts "paper" questionnaires into inter
 
 ## Installation
 
-Eventually this will be published to PyPy but for now follow the instructions in [installation.md](installation.md).
+Eventually this will be published to PyPI but for now follow the instructions in [installation.md](installation.md).
 
 ## Setup
 Survaize requires an OpenAI API key. You can specify it using the --api-key parameter or by setting in the OPENAI_API_KEY environment variable.


### PR DESCRIPTION
## Summary
- fix typo in README referring to PyPI

## Testing
- `pytest -q` *(fails: No module named 'openai', 'yaml', 'PIL', 'cv2', 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6845a88852408320a6026a00cb8cb60a