### PR TITLE
Fix docstring in cspro_writer

### DIFF
--- a/src/survaize/writer/cspro_writer.py
+++ b/src/survaize/writer/cspro_writer.py
@@ -94,7 +94,6 @@ class CSProWriter:
 
         Args:
             questionnaire: The questionnaire data
-            output_path: Path to save the generated file
 
         Returns:
             The generated CSPro dictionary and a mapping of dictionary item to question that it was created from


### PR DESCRIPTION
## Summary
- remove outdated `output_path` parameter reference in `_generate_data_dictionary` docstring

## Testing
- `python devtools/lint.py` *(fails: ModuleNotFoundError: No module named 'funlog')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai', 'yaml', 'PIL', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6845a8831d288320ba95dfe37efab709