### PR TITLE
Refactor readers to accept file objects

### DIFF
--- a/evals/datasets/pdf_to_questionnaire_dataset.py
+++ b/evals/datasets/pdf_to_questionnaire_dataset.py
@@ -22,7 +22,8 @@ def _create_case(
     metadata: CaseMetadata,
 ) -> Case[Path, Questionnaire, CaseMetadata]:
 
-    ground_truth_json = JSONReader().read(ground_truth_json_path)
+    with open(ground_truth_json_path, "rb") as f:
+        ground_truth_json = JSONReader().read(f)
     return Case(
         name=name,
         inputs=input_path,

--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -15,7 +15,8 @@ async def convert_questionnaire(pdf_path: Path) -> Questionnaire:
 
     interpreter = AIQuestionnaireInterpreter(llm_config=config)
     pdf_reader = PDFReader(interpreter)
-    questionnaire = pdf_reader.read(pdf_path)
+    with open(pdf_path, "rb") as f:
+        questionnaire = pdf_reader.read(f)
     return questionnaire
 
 

--- a/src/survaize/convert/converter.py
+++ b/src/survaize/convert/converter.py
@@ -39,7 +39,8 @@ class QuestionnaireConverter:
         reader = self.reader_factory.get(input_format_str)
 
         logger.info(f"Reading questionnaire: {input_file}")
-        questionnaire = reader.read(input_file)
+        with open(input_file, "rb") as f:
+            questionnaire = reader.read(f)
 
         writer = self.writer_factory.get(output_format)
 

--- a/src/survaize/reader/json_reader.py
+++ b/src/survaize/reader/json_reader.py
@@ -1,5 +1,5 @@
 import json
-from pathlib import Path
+from typing import IO
 
 from survaize.model.questionnaire import Questionnaire
 
@@ -7,14 +7,14 @@ from survaize.model.questionnaire import Questionnaire
 class JSONReader:
     """Read questionnaire from JSON file (Survaize JSON schema)."""
 
-    def read(self, file_path: Path) -> Questionnaire:
+    def read(self, file: IO[bytes]) -> Questionnaire:
         """Read a document and extract its content.
 
         Args:
-            file_path: Path to the document file
+            file: File-like object containing the JSON questionnaire
 
         Returns:
             A Questionnaire containing the extracted content
         """
-        with open(file_path) as f:
-            return Questionnaire.model_validate(json.load(f))
+        file.seek(0)
+        return Questionnaire.model_validate(json.load(file))

--- a/src/survaize/reader/reader.py
+++ b/src/survaize/reader/reader.py
@@ -1,5 +1,4 @@
-from pathlib import Path
-from typing import Protocol
+from typing import IO, Protocol
 
 from survaize.model.questionnaire import Questionnaire
 
@@ -7,11 +6,11 @@ from survaize.model.questionnaire import Questionnaire
 class Reader(Protocol):
     """Protocol defining the interface for questionnaire readers."""
 
-    def read(self, file_path: Path) -> Questionnaire:
+    def read(self, file: IO[bytes]) -> Questionnaire:
         """Read a document and extract its content.
 
         Args:
-            file_path: Path to the document file
+            file: File-like object positioned at the beginning of the document
 
         Returns:
             A Questionnaire containing the extracted content

--- a/tests/test_cspro_writer.py
+++ b/tests/test_cspro_writer.py
@@ -17,7 +17,8 @@ def test_cspro_writer_generates_expected_files(tmp_path: Path) -> None:
     """CSProWriter.write should generate files matching the cspro fixtures."""
     # Read questionnaire from JSON fixture
     reader = JSONReader()
-    questionnaire = reader.read(json_fixture_file)
+    with open(json_fixture_file, "rb") as f:
+        questionnaire = reader.read(f)
 
     # Prepare output path
     output_file = tmp_path / f"{questionnaire.title}.cspro"


### PR DESCRIPTION
## Summary
- change `Reader` protocol to accept an `IO[bytes]`
- update `JSONReader` and `PDFReader` implementations
- adjust `read_questionnaire` route to pass `UploadFile.file`
- update converter and evaluation helpers
- adapt tests

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6846d748dcfc83209811e1a9a1dabe4e