### PR TITLE
Improve questionnaire loading display

### DIFF
--- a/src/survaize/web/frontend/src/components/QuestionnaireDisplay.tsx
+++ b/src/survaize/web/frontend/src/components/QuestionnaireDisplay.tsx
@@ -84,7 +84,21 @@ const renderQuestion = (question: Question) => {
 };
 
 export const QuestionnaireDisplay: React.FC = () => {
-  const { questionnaire } = useQuestionnaire();
+  const { questionnaire, isLoading, loadProgress, loadMessage } = useQuestionnaire();
+
+  if (isLoading) {
+    return (
+      <div className="questionnaire-loading">
+        <div className="loading-animation" role="img" aria-label="Processing">
+          📝
+        </div>
+        <p>{loadMessage} ({Math.round(loadProgress)}%)</p>
+        <div className="progress-bar-container">
+          <div className="progress-bar" style={{ width: `${loadProgress}%` }}></div>
+        </div>
+      </div>
+    );
+  }
 
   if (!questionnaire) {
     return (

--- a/src/survaize/web/frontend/src/index.css
+++ b/src/survaize/web/frontend/src/index.css
@@ -163,6 +163,24 @@ button:focus-visible {
   transition: width 0.3s ease;
 }
 
+/* Loading view */
+.questionnaire-loading {
+  text-align: center;
+  padding: 2rem;
+}
+
+.loading-animation {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+  display: inline-block;
+  animation: bounce 1s infinite alternate;
+}
+
+@keyframes bounce {
+  from { transform: translateY(0); }
+  to { transform: translateY(-10px); }
+}
+
 /* Error messages */
 .error-message {
   color: var(--error-color);


### PR DESCRIPTION
## Summary
- track questionnaire loading progress in context
- show PDF processing progress in the main questionnaire view
- simplify open button text
- add bouncing pencil animation for loading view

## Testing
- `uv run python devtools/lint.py`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_684726a4453c8320950f3178ea9516de