### PR TITLE
Add browser auto-launch

### DIFF
--- a/development.md
+++ b/development.md
@@ -28,6 +28,8 @@ uv run survaize
 
 # Start the web UI (default on port 8000)
 uv run survaize ui
+# Disable automatic browser launch
+uv run survaize ui --no-browser
 
 # Linting:
 uv run python devtools/lint.py

--- a/src/survaize/interpreter/ai_interpreter.py
+++ b/src/survaize/interpreter/ai_interpreter.py
@@ -86,6 +86,9 @@ class AIQuestionnaireInterpreter:
                 partial_questionnaire = self._process_subsequent_page(page, text, i, current_state)
                 current_state = merge_questionnaires(current_state, partial_questionnaire)
 
+        if progress_callback:
+            progress_callback(100, "Complete")
+
         if current_state is None:
             raise ValueError("No valid questionnaire found in the document")
         return current_state

--- a/src/survaize/main.py
+++ b/src/survaize/main.py
@@ -2,6 +2,8 @@
 
 import logging
 import os
+import threading
+import webbrowser
 from pathlib import Path
 from typing import Literal
 
@@ -157,6 +159,12 @@ def convert(
     default="gpt-4.1",
     help="OpenAI API model name (can also be set via OPENAI_API_MODEL env var). Defaults to gpt-4.1",
 )
+@click.option(
+    "--no-browser",
+    is_flag=True,
+    default=False,
+    help="Do not open the web UI in a browser automatically",
+)
 def ui(
     host: str,
     port: int,
@@ -166,6 +174,7 @@ def ui(
     api_version: str | None,
     api_url: str | None,
     api_model: str,
+    no_browser: bool,
 ) -> None:
     """Start the Survaize web application server."""
     try:
@@ -185,7 +194,11 @@ def ui(
             os.environ["OPENAI_API_URL"] = api_url
         os.environ["OPENAI_API_MODEL"] = api_model
 
-        # TODO: launch browser automatically
+        if not no_browser:
+            url = f"http://{host}:{port}"
+            console.log(f"[green]Opening {url} in your browser...[/green]")
+            threading.Timer(1.0, webbrowser.open, args=(url,)).start()
+
         run_server(host=host, port=port, reload=reload)
     except Exception as e:
         console.log(f"[red]Error starting web server: {e}")

--- a/src/survaize/reader/pdf_reader.py
+++ b/src/survaize/reader/pdf_reader.py
@@ -52,7 +52,7 @@ class PDFReader:
         texts: list[str] = []
         for i, page in enumerate(pages, start=1):
             if progress_callback:
-                percent = int(10 * (i  - 1) / len(pages))
+                percent = int(10 * (i - 1) / len(pages))
                 progress_callback(percent, f"Extracting image from page {i}/{len(pages)}")
             texts.append(self._process_page(page))
 


### PR DESCRIPTION
## Summary
- open system browser when starting the web UI
- add `--no-browser` CLI flag
- document the option in development workflow
- fix a progress callback in `AIQuestionnaireInterpreter`
- minor whitespace fix in `PDFReader`

## Testing
- `uv run python devtools/lint.py`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_684826aca5cc83209304bf607bbd6520