### PR TITLE
Add frontend lint/test tooling

### DIFF
--- a/development.md
+++ b/development.md
@@ -22,6 +22,8 @@ uv sync --all-extras --dev
 cd web/frontend
 npm install
 npm run build
+npm run lint  # run ESLint checks for the React frontend
+npm test      # run Vitest unit tests
 
 # Run the application (add --help to see command options)
 uv run survaize
@@ -74,12 +76,19 @@ The web UI frontend is a React application built with Vite. It lives in the web/
 directory. When you run `npm run build` in the web/frontend directory, it will compile the
 frontend assets and place them in the web/static directory, which is served by the backend.
 
-If you want to edit the frontend code, you can start the frontend development server with hot 
+If you want to edit the frontend code, you can start the frontend development server with hot
 reload with:
 
 ```shell
 cd web/frontend
 npm run dev
+```
+
+Run ESLint and unit tests for the frontend with:
+
+```shell
+npm run lint
+npm test
 ```
 
 This will start the frontend development server with hot reload on port 3000 by default. You can then

--- a/src/survaize/interpreter/ai_interpreter.py
+++ b/src/survaize/interpreter/ai_interpreter.py
@@ -88,6 +88,8 @@ class AIQuestionnaireInterpreter:
 
         if current_state is None:
             raise ValueError("No valid questionnaire found in the document")
+        if progress_callback:
+            progress_callback(100, "Completed")
         return current_state
 
     def _process_first_page(self, image: Image.Image, ocr_text: str) -> Questionnaire:

--- a/src/survaize/reader/pdf_reader.py
+++ b/src/survaize/reader/pdf_reader.py
@@ -52,7 +52,7 @@ class PDFReader:
         texts: list[str] = []
         for i, page in enumerate(pages, start=1):
             if progress_callback:
-                percent = int(10 * (i  - 1) / len(pages))
+                percent = int(10 * (i - 1) / len(pages))
                 progress_callback(percent, f"Extracting image from page {i}/{len(pages)}")
             texts.append(self._process_page(page))
 

--- a/src/survaize/web/frontend/.eslintrc.cjs
+++ b/src/survaize/web/frontend/.eslintrc.cjs
@@ -1,0 +1,25 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2021: true,
+    node: true,
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['react', '@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:@typescript-eslint/recommended',
+    'prettier',
+  ],
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+};

--- a/src/survaize/web/frontend/package.json
+++ b/src/survaize/web/frontend/package.json
@@ -8,7 +8,9 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "vitest run",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "format": "prettier --write \"src/**/*.{ts,tsx}\""
   },
   "keywords": [],
   "author": "",
@@ -23,6 +25,15 @@
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.5.1",
     "typescript": "^5.8.3",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "eslint": "^8.56.0",
+    "eslint-plugin-react": "^7.34.0",
+    "@typescript-eslint/parser": "^7.11.0",
+    "@typescript-eslint/eslint-plugin": "^7.11.0",
+    "prettier": "^3.2.5",
+    "vitest": "^1.4.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.2.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/src/survaize/web/frontend/src/__tests__/App.test.tsx
+++ b/src/survaize/web/frontend/src/__tests__/App.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import App from '../App';
+
+vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true }) as Response));
+
+test('renders application heading', async () => {
+  render(<App />);
+  const heading = await screen.findByRole('heading', { name: /Survaize/i });
+  expect(heading).toBeInTheDocument();
+});

--- a/src/survaize/web/frontend/src/setupTests.ts
+++ b/src/survaize/web/frontend/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/src/survaize/web/frontend/vitest.config.ts
+++ b/src/survaize/web/frontend/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/setupTests.ts',
+  },
+});


### PR DESCRIPTION
## Summary
- configure ESLint and Vitest for the React frontend
- add a sample test for the `App` component
- document new `npm` scripts in development guide
- report completion progress in interpreter

## Testing
- `uv run python devtools/lint.py`
- `uv run pytest`

`npm install` was attempted but failed with 403 errors so frontend tests could not be run.

------
https://chatgpt.com/codex/tasks/task_e_6847271198048320b182e2a2c1c70ac5