### PR TITLE
Display numeric range in UI

### DIFF
--- a/src/survaize/web/frontend/src/__tests__/QuestionItem.test.tsx
+++ b/src/survaize/web/frontend/src/__tests__/QuestionItem.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import QuestionItem from "../components/QuestionItem";
+import { QuestionType, NumericQuestion } from "../models/questionnaire";
+
+test("renders range for numeric question", () => {
+  const question: NumericQuestion = {
+    number: "1",
+    id: "age",
+    text: "Age?",
+    type: QuestionType.NUMERIC,
+    min_value: 18,
+    max_value: 65,
+    decimal_places: null,
+  };
+  render(<QuestionItem question={question} />);
+  expect(screen.getByText("Range: 18-65")).toBeInTheDocument();
+});
+
+test("renders negative infinity when min missing", () => {
+  const question: NumericQuestion = {
+    number: "2",
+    id: "id2",
+    text: "Weight?",
+    type: QuestionType.NUMERIC,
+    min_value: null,
+    max_value: 20,
+    decimal_places: null,
+  };
+  render(<QuestionItem question={question} />);
+  expect(screen.getByText("Range: -∞-20")).toBeInTheDocument();
+});
+
+test("hides range line when both bounds missing", () => {
+  const question: NumericQuestion = {
+    number: "3",
+    id: "id3",
+    text: "Value?",
+    type: QuestionType.NUMERIC,
+    min_value: null,
+    max_value: null,
+    decimal_places: null,
+  };
+  render(<QuestionItem question={question} />);
+  const range = screen.queryByText(/Range:/i);
+  expect(range).toBeNull();
+});

--- a/src/survaize/web/frontend/src/components/QuestionItem.tsx
+++ b/src/survaize/web/frontend/src/components/QuestionItem.tsx
@@ -6,7 +6,10 @@ interface QuestionItemProps {
   isIdField?: boolean;
 }
 
-const QuestionItem: React.FC<QuestionItemProps> = ({ question, isIdField = false }) => {
+const QuestionItem: React.FC<QuestionItemProps> = ({
+  question,
+  isIdField = false,
+}) => {
   let details: React.ReactNode = null;
 
   switch (question.type) {
@@ -25,17 +28,27 @@ const QuestionItem: React.FC<QuestionItemProps> = ({ question, isIdField = false
         </div>
       );
       break;
-    case QuestionType.NUMERIC:
+    case QuestionType.NUMERIC: {
+      const showRange =
+        question.min_value !== null || question.max_value !== null;
+      const minDisplay =
+        question.min_value !== null ? question.min_value : "-∞";
+      const maxDisplay = question.max_value !== null ? question.max_value : "∞";
+
       details = (
         <div className="question-constraints">
-          {question.min_value !== null && <div>Min: {question.min_value}</div>}
-          {question.max_value !== null && <div>Max: {question.max_value}</div>}
+          {showRange && (
+            <div>
+              Range: {minDisplay}-{maxDisplay}
+            </div>
+          )}
           {question.decimal_places !== null && (
             <div>Decimal places: {question.decimal_places}</div>
           )}
         </div>
       );
       break;
+    }
     case QuestionType.TEXT:
       details =
         question.max_length !== null ? (


### PR DESCRIPTION
## Summary
- show numeric ranges in the questionnaire UI
- test numeric range rendering

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `uv run python devtools/lint.py`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_684887c632ec8320a6495a8576181896