### PR TITLE
Fix numeric/text field display in questionnaire UI

### DIFF
--- a/src/survaize/web/frontend/src/__tests__/QuestionItem.test.tsx
+++ b/src/survaize/web/frontend/src/__tests__/QuestionItem.test.tsx
@@ -54,6 +54,18 @@ test("hides range line when both bounds missing", () => {
   expect(range).toBeNull();
 });
 
+test("hides range and decimals when properties omitted", () => {
+  const question: NumericQuestion = {
+    number: "9",
+    id: "omit",
+    text: "Any number?",
+    type: QuestionType.NUMERIC,
+  };
+  render(<QuestionItem question={question} />);
+  expect(screen.queryByText(/Range:/i)).toBeNull();
+  expect(screen.queryByText(/Decimal places:/i)).toBeNull();
+});
+
 test("renders correct tooltip for numeric question", () => {
   const question: NumericQuestion = {
     number: "1",
@@ -112,6 +124,17 @@ test("renders correct icon and tooltip for text question", () => {
   render(<QuestionItem question={question} />);
   const iconElement = screen.getByRole("img", { hidden: true });
   expect(iconElement.parentElement).toHaveAttribute("title", "Text");
+});
+
+test("hides max length when property omitted", () => {
+  const question: TextQuestion = {
+    number: "10",
+    id: "desc",
+    text: "Describe yourself",
+    type: QuestionType.TEXT,
+  };
+  render(<QuestionItem question={question} />);
+  expect(screen.queryByText(/Max length:/i)).toBeNull();
 });
 
 test("renders correct icon and tooltip for date question", () => {

--- a/src/survaize/web/frontend/src/components/QuestionItem.tsx
+++ b/src/survaize/web/frontend/src/components/QuestionItem.tsx
@@ -63,10 +63,9 @@ const QuestionItem: React.FC<QuestionItemProps> = ({
     }
     case QuestionType.NUMERIC: {
       const showRange =
-        question.min_value !== null || question.max_value !== null;
-      const minDisplay =
-        question.min_value !== null ? question.min_value : "-∞";
-      const maxDisplay = question.max_value !== null ? question.max_value : "∞";
+        question.min_value != null || question.max_value != null;
+      const minDisplay = question.min_value != null ? question.min_value : "-∞";
+      const maxDisplay = question.max_value != null ? question.max_value : "∞";
       details = (
         <div className="question-constraints">
           {showRange && (
@@ -74,7 +73,7 @@ const QuestionItem: React.FC<QuestionItemProps> = ({
               Range: {minDisplay}-{maxDisplay}
             </div>
           )}
-          {question.decimal_places !== null && (
+          {question.decimal_places != null && (
             <div>Decimal places: {question.decimal_places}</div>
           )}
         </div>
@@ -83,7 +82,7 @@ const QuestionItem: React.FC<QuestionItemProps> = ({
     }
     case QuestionType.TEXT:
       details =
-        question.max_length !== null ? (
+        question.max_length != null ? (
           <div className="question-constraints">
             Max length: {question.max_length}
           </div>


### PR DESCRIPTION
## Summary
- avoid showing empty range or decimal info for numeric questions
- avoid showing empty max length for text questions
- test rendering when numeric range/decimals are omitted
- test rendering when text max length is omitted

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `uv run python devtools/lint.py`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68545b67585c8320b05d45bc5a20b1b4