### PR TITLE
Move JSON toggle button

### DIFF
--- a/src/survaize/web/frontend/src/App.tsx
+++ b/src/survaize/web/frontend/src/App.tsx
@@ -50,8 +50,10 @@ const App: React.FC = () => {
             </div>
           </header>
           <div className="toolbar">
-            <OpenQuestionnaire />
-            <SaveQuestionnaire />
+            <div className="toolbar-left">
+              <OpenQuestionnaire />
+              <SaveQuestionnaire />
+            </div>
             <button
               className="icon-button"
               onClick={toggleShowRaw}

--- a/src/survaize/web/frontend/src/App.tsx
+++ b/src/survaize/web/frontend/src/App.tsx
@@ -9,6 +9,11 @@ import { QuestionnaireDisplay } from "./components/QuestionnaireDisplay";
 const App: React.FC = () => {
   const [apiStatus, setApiStatus] = useState<string>("");
   const [isApiConnected, setIsApiConnected] = useState<boolean | null>(null);
+  const [showRaw, setShowRaw] = useState<boolean>(false);
+
+  const toggleShowRaw = (): void => {
+    setShowRaw((prev) => !prev);
+  };
 
   useEffect(() => {
     // Check API health
@@ -47,10 +52,17 @@ const App: React.FC = () => {
           <div className="toolbar">
             <OpenQuestionnaire />
             <SaveQuestionnaire />
+            <button
+              className="icon-button"
+              onClick={toggleShowRaw}
+              title={showRaw ? "Show formatted view" : "Show raw JSON"}
+            >
+              {"{}"}
+            </button>
           </div>
         </div>
         <div className="main-content">
-          <QuestionnaireDisplay />
+          <QuestionnaireDisplay showRaw={showRaw} />
         </div>
       </div>
     </QuestionnaireProvider>

--- a/src/survaize/web/frontend/src/__tests__/QuestionnaireDisplay.test.tsx
+++ b/src/survaize/web/frontend/src/__tests__/QuestionnaireDisplay.test.tsx
@@ -29,4 +29,7 @@ test("shows editor when showRaw is true", () => {
     </QuestionnaireContext.Provider>,
   );
   expect(document.querySelector(".cm-editor")).toBeInTheDocument();
+  expect(
+    document.querySelector(".questionnaire-header"),
+  ).not.toBeInTheDocument();
 });

--- a/src/survaize/web/frontend/src/__tests__/QuestionnaireDisplay.test.tsx
+++ b/src/survaize/web/frontend/src/__tests__/QuestionnaireDisplay.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { vi } from "vitest";
 import { QuestionnaireDisplay } from "../components/QuestionnaireDisplay";
 import { QuestionnaireContext } from "../components/QuestionnaireComponents";
@@ -22,13 +22,11 @@ const contextValue: React.ContextType<typeof QuestionnaireContext> = {
   setLoadMessage: vi.fn(),
 };
 
-test("shows editor when toggled", () => {
+test("shows editor when showRaw is true", () => {
   render(
     <QuestionnaireContext.Provider value={contextValue}>
-      <QuestionnaireDisplay />
+      <QuestionnaireDisplay showRaw={true} />
     </QuestionnaireContext.Provider>,
   );
-  const toggle = screen.getByTitle(/Show raw JSON/i);
-  fireEvent.click(toggle);
   expect(document.querySelector(".cm-editor")).toBeInTheDocument();
 });

--- a/src/survaize/web/frontend/src/components/QuestionnaireDisplay.tsx
+++ b/src/survaize/web/frontend/src/components/QuestionnaireDisplay.tsx
@@ -27,14 +27,16 @@ import {
 } from "@codemirror/autocomplete";
 import { EditorView, keymap } from "@codemirror/view";
 
-export const QuestionnaireDisplay: React.FC = () => {
-  const [showRaw, setShowRaw] = useState<boolean>(false);
+interface QuestionnaireDisplayProps {
+  showRaw: boolean;
+}
+
+export const QuestionnaireDisplay: React.FC<QuestionnaireDisplayProps> = ({
+  showRaw,
+}) => {
   const [editorValue, setEditorValue] = useState<string>("");
   const [parseError, setParseError] = useState<string | null>(null);
 
-  const toggleView = (): void => {
-    setShowRaw((prev) => !prev);
-  };
   const {
     questionnaire,
     isLoading,
@@ -96,13 +98,6 @@ export const QuestionnaireDisplay: React.FC = () => {
           <h2>{questionnaire.title}</h2>
           {questionnaire.description && <p>{questionnaire.description}</p>}
         </div>
-        <button
-          className="icon-button"
-          onClick={toggleView}
-          title={showRaw ? "Show formatted view" : "Show raw JSON"}
-        >
-          {"{}"}
-        </button>
       </div>
 
       {showRaw ? (

--- a/src/survaize/web/frontend/src/components/QuestionnaireDisplay.tsx
+++ b/src/survaize/web/frontend/src/components/QuestionnaireDisplay.tsx
@@ -93,12 +93,14 @@ export const QuestionnaireDisplay: React.FC<QuestionnaireDisplayProps> = ({
 
   return (
     <div className="questionnaire-display">
-      <div className="questionnaire-header">
-        <div>
-          <h2>{questionnaire.title}</h2>
-          {questionnaire.description && <p>{questionnaire.description}</p>}
+      {!showRaw && (
+        <div className="questionnaire-header">
+          <div>
+            <h2>{questionnaire.title}</h2>
+            {questionnaire.description && <p>{questionnaire.description}</p>}
+          </div>
         </div>
-      </div>
+      )}
 
       {showRaw ? (
         <div className="json-display">

--- a/src/survaize/web/frontend/src/index.css
+++ b/src/survaize/web/frontend/src/index.css
@@ -65,13 +65,14 @@ body {
 
 .toolbar {
   display: flex;
-  justify-content: space-between;
   align-items: center;
   margin-bottom: 1rem;
 }
 
 .toolbar-left {
+  flex: 1;
   display: flex;
+  justify-content: center;
   gap: 1rem;
 }
 
@@ -150,6 +151,11 @@ button {
 
 .icon-button:hover {
   color: var(--primary-color);
+}
+
+/* Position the JSON toggle at the far right of the toolbar */
+.toolbar > .icon-button {
+  margin-left: auto;
 }
 
 button:disabled {

--- a/src/survaize/web/frontend/src/index.css
+++ b/src/survaize/web/frontend/src/index.css
@@ -65,9 +65,14 @@ body {
 
 .toolbar {
   display: flex;
-  justify-content: center;
-  gap: 1rem;
+  justify-content: space-between;
+  align-items: center;
   margin-bottom: 1rem;
+}
+
+.toolbar-left {
+  display: flex;
+  gap: 1rem;
 }
 
 .main-content {


### PR DESCRIPTION
## Summary
- move the JSON view toggle button to the toolbar so it stays visible
- adjust QuestionnaireDisplay to receive `showRaw` prop
- update tests
- revert sticky header styling

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `uv run python devtools/lint.py`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68545f50ed7c83208922c56608cfcc83