### PR TITLE
Add OpenAI recording wrapper

### DIFF
--- a/development.md
+++ b/development.md
@@ -73,6 +73,13 @@ source .venv/bin/activate
 
 See [uv docs](https://docs.astral.sh/uv/) for details.
 
+### Recording OpenAI Responses
+
+You can record or replay API calls made to the OpenAI client. Set
+`OPENAI_RECORDING_MODE` to `record` to save responses, or `replay` to load
+previously recorded ones from the directory pointed to by
+`OPENAI_RECORDING_DIR` (default `openai_records`).
+
 ## Frontend Development
 
 The web UI frontend is a React application built with Vite. It lives in the web/frontend

--- a/src/survaize/interpreter/ai_interpreter.py
+++ b/src/survaize/interpreter/ai_interpreter.py
@@ -15,7 +15,11 @@ from openai.types.chat import (
 from PIL import Image
 from pydantic import BaseModel
 
-from survaize.config.llm_config import LLMConfig, OpenAIProviderType
+from survaize.config.llm_config import LLMConfig
+from survaize.interpreter.openai_recorder import (
+    RecordingClient,
+    create_openai_client,
+)
 from survaize.interpreter.scanned_questionnaire import ScannedQuestionnaire
 from survaize.model.questionnaire import PartialQuestionnaire, Questionnaire, merge_questionnaires
 
@@ -35,18 +39,7 @@ class AIQuestionnaireInterpreter:
             llm_config: Configuration/keys for the OpenAI API
         """
         self.llm_config: LLMConfig = llm_config
-        if llm_config.provider == OpenAIProviderType.AZURE:
-            assert llm_config.api_url is not None
-            self.client: OpenAI | AzureOpenAI = AzureOpenAI(
-                api_key=llm_config.api_key,
-                api_version=llm_config.api_version,
-                azure_endpoint=llm_config.api_url,
-            )
-        else:  # default to openai client
-            self.client = OpenAI(
-                api_key=llm_config.api_key,
-                base_url=llm_config.api_url,
-            )
+        self.client: AzureOpenAI | OpenAI | RecordingClient = create_openai_client(llm_config)
         self.max_retries: int = max_retries
 
     def interpret(

--- a/src/survaize/interpreter/openai_recorder.py
+++ b/src/survaize/interpreter/openai_recorder.py
@@ -1,0 +1,104 @@
+import json
+import os
+from datetime import UTC, datetime
+from enum import Enum
+from pathlib import Path
+
+from openai import AzureOpenAI, OpenAI
+from openai.types.chat import ChatCompletion
+
+from survaize.config.llm_config import LLMConfig, OpenAIProviderType
+
+
+class RecordingMode(Enum):
+    """Mode for the :class:`RecordingClient`."""
+
+    OFF = "off"
+    RECORD = "record"
+    REPLAY = "replay"
+
+
+class _RecordingCompletions:
+    _client: AzureOpenAI | OpenAI
+    _mode: RecordingMode
+    _directory: Path
+    _counter: list[int]
+
+    def __init__(self, client: AzureOpenAI | OpenAI, mode: RecordingMode, directory: Path, counter: list[int]) -> None:
+        self._client = client
+        self._mode = mode
+        self._directory = directory
+        self._counter = counter
+
+    def create(self, *args: object, **kwargs: object) -> ChatCompletion:
+        self._counter[0] += 1
+        file_path = self._directory / f"{self._counter[0]:03d}.json"
+        if self._mode is RecordingMode.REPLAY:
+            with open(file_path) as f:
+                data = json.load(f)
+            return ChatCompletion.model_validate(data["response"])
+        response = self._client.chat.completions.create(*args, **kwargs)
+        if self._mode is RecordingMode.RECORD:
+            self._directory.mkdir(parents=True, exist_ok=True)
+            with open(file_path, "w") as f:
+                json.dump(
+                    {"request": {"args": args, "kwargs": kwargs}, "response": response.model_dump()},
+                    f,
+                    indent=2,
+                )
+        return response
+
+
+class _RecordingChat:
+    completions: _RecordingCompletions
+
+    def __init__(self, client: AzureOpenAI | OpenAI, mode: RecordingMode, directory: Path, counter: list[int]) -> None:
+        self.completions = _RecordingCompletions(client, mode, directory, counter)
+
+
+class RecordingClient:
+    """OpenAI client wrapper that records or replays chat completions."""
+
+    _client: AzureOpenAI | OpenAI
+    _mode: RecordingMode
+    _base_directory: Path
+    _directory: Path
+    _counter: list[int]
+    chat: _RecordingChat
+
+    def __init__(self, client: AzureOpenAI | OpenAI, mode: RecordingMode, directory: Path) -> None:
+        self._client = client
+        self._mode = mode
+        self._base_directory = directory
+        if mode is RecordingMode.RECORD:
+            self._directory = directory / datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
+        else:
+            self._directory = directory
+        self._counter = [0]
+        self.chat = _RecordingChat(client, mode, self._directory, self._counter)
+
+    def __getattr__(self, item: str) -> object:  # pragma: no cover - passthrough
+        return getattr(self._client, item)
+
+
+def create_openai_client(llm_config: LLMConfig) -> AzureOpenAI | OpenAI | RecordingClient:
+    """Create an OpenAI client optionally wrapped for recording or replay."""
+    if llm_config.provider == OpenAIProviderType.AZURE:
+        assert llm_config.api_url is not None
+        client: AzureOpenAI | OpenAI = AzureOpenAI(
+            api_key=llm_config.api_key,
+            api_version=llm_config.api_version,
+            azure_endpoint=llm_config.api_url,
+        )
+    else:
+        client = OpenAI(api_key=llm_config.api_key, base_url=llm_config.api_url)
+
+    mode_str = os.environ.get("OPENAI_RECORDING_MODE", "off").lower()
+    try:
+        mode = RecordingMode(mode_str)
+    except ValueError:  # pragma: no cover - invalid mode falls back to off
+        mode = RecordingMode.OFF
+    directory = Path(os.environ.get("OPENAI_RECORDING_DIR", "openai_records"))
+    if mode is not RecordingMode.OFF:
+        return RecordingClient(client, mode, directory)
+    return client

--- a/tests/test_ai_interpreter.py
+++ b/tests/test_ai_interpreter.py
@@ -47,10 +47,10 @@ def mock_llm_config() -> LLMConfig:
 
 def test_first_page_retry_validation_error(mock_document: ScannedQuestionnaire, mock_llm_config: LLMConfig):
     """Test that _process_first_page retries when Pydantic validation fails."""
-    with patch("survaize.interpreter.ai_interpreter.OpenAI") as mock_openai:
+    with patch("survaize.interpreter.ai_interpreter.create_openai_client") as mock_factory:
         # Set up the mock for OpenAI client
         mock_client = MagicMock()
-        mock_openai.return_value = mock_client
+        mock_factory.return_value = mock_client
 
         # Configure mock responses - first with invalid JSON, then with valid JSON
         mock_completion1 = MagicMock()
@@ -94,10 +94,10 @@ def test_first_page_retry_validation_error(mock_document: ScannedQuestionnaire, 
 
 def test_max_retries_exceeded(mock_document: ScannedQuestionnaire, mock_llm_config: LLMConfig):
     """Test that _process_first_page raises an error after max retries."""
-    with patch("survaize.interpreter.ai_interpreter.OpenAI") as mock_openai:
+    with patch("survaize.interpreter.ai_interpreter.create_openai_client") as mock_factory:
         # Set up the mock for OpenAI client
         mock_client = MagicMock()
-        mock_openai.return_value = mock_client
+        mock_factory.return_value = mock_client
 
         # Configure mock response with always-invalid JSON
         mock_completion = MagicMock()
@@ -127,9 +127,9 @@ def test_max_retries_exceeded(mock_document: ScannedQuestionnaire, mock_llm_conf
 
 def test_interpret_reports_progress(mock_document_two_pages: ScannedQuestionnaire, mock_llm_config: LLMConfig) -> None:
     """Verify interpret emits progress updates for each page."""
-    with patch("survaize.interpreter.ai_interpreter.OpenAI") as mock_openai:
+    with patch("survaize.interpreter.ai_interpreter.create_openai_client") as mock_factory:
         mock_client = MagicMock()
-        mock_openai.return_value = mock_client
+        mock_factory.return_value = mock_client
 
         completion1 = MagicMock()
         completion1.choices[0].message.content = json.dumps(


### PR DESCRIPTION
## Summary
- wrap OpenAI client with a recording client that can record or replay responses
- use `RecordingMode` enum instead of string flags
- ensure recordings are stored in timestamped subdirectories
- document `OPENAI_RECORDING_MODE` and `OPENAI_RECORDING_DIR` in development guide
- create factory to return `RecordingClient` when enabled

## Testing
- `uv run python devtools/lint.py`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854774d9e4083208780bd3cd4618bc5