### PR TITLE
Preserve scroll position when switching views

### DIFF
--- a/src/survaize/web/frontend/src/App.tsx
+++ b/src/survaize/web/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import {
   QuestionnaireProvider,
   OpenQuestionnaire,
@@ -10,6 +10,7 @@ const App: React.FC = () => {
   const [apiStatus, setApiStatus] = useState<string>("");
   const [isApiConnected, setIsApiConnected] = useState<boolean | null>(null);
   const [showRaw, setShowRaw] = useState<boolean>(false);
+  const mainContentRef = useRef<HTMLDivElement>(null);
 
   const toggleShowRaw = (): void => {
     setShowRaw((prev) => !prev);
@@ -63,8 +64,11 @@ const App: React.FC = () => {
             </button>
           </div>
         </div>
-        <div className="main-content">
-          <QuestionnaireDisplay showRaw={showRaw} />
+        <div className="main-content" ref={mainContentRef}>
+          <QuestionnaireDisplay
+            showRaw={showRaw}
+            containerRef={mainContentRef}
+          />
         </div>
       </div>
     </QuestionnaireProvider>

--- a/src/survaize/web/frontend/src/__tests__/QuestionnaireDisplay.test.tsx
+++ b/src/survaize/web/frontend/src/__tests__/QuestionnaireDisplay.test.tsx
@@ -1,4 +1,5 @@
 import { render } from "@testing-library/react";
+import React from "react";
 import { vi } from "vitest";
 import { QuestionnaireDisplay } from "../components/QuestionnaireDisplay";
 import { QuestionnaireContext } from "../components/QuestionnaireComponents";
@@ -23,10 +24,13 @@ const contextValue: React.ContextType<typeof QuestionnaireContext> = {
 };
 
 test("shows editor when showRaw is true", () => {
+  const ref = React.createRef<HTMLDivElement>();
   render(
-    <QuestionnaireContext.Provider value={contextValue}>
-      <QuestionnaireDisplay showRaw={true} />
-    </QuestionnaireContext.Provider>,
+    <div ref={ref}>
+      <QuestionnaireContext.Provider value={contextValue}>
+        <QuestionnaireDisplay showRaw={true} containerRef={ref} />
+      </QuestionnaireContext.Provider>
+    </div>,
   );
   expect(document.querySelector(".cm-editor")).toBeInTheDocument();
   expect(

--- a/src/survaize/web/frontend/src/components/QuestionItem.tsx
+++ b/src/survaize/web/frontend/src/components/QuestionItem.tsx
@@ -108,7 +108,12 @@ const QuestionItem: React.FC<QuestionItemProps> = ({
   }
 
   return (
-    <div className="question-item" key={question.id}>
+    <div
+      className="question-item"
+      key={question.id}
+      id={`question-${question.id}`}
+      data-question-id={question.id}
+    >
       <div className="question-header">
         <span className="question-number">{question.number}</span>
         <span className="question-id">[{question.id}]</span>

--- a/src/survaize/web/frontend/src/components/QuestionnaireDisplay.tsx
+++ b/src/survaize/web/frontend/src/components/QuestionnaireDisplay.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import CodeMirror, {
   drawSelection,
   gutter,
@@ -29,13 +29,24 @@ import { EditorView, keymap } from "@codemirror/view";
 
 interface QuestionnaireDisplayProps {
   showRaw: boolean;
+  /**
+   * Reference to the scrolling container wrapping this component.
+   * Used to synchronize scroll position between views.
+   */
+  containerRef: React.RefObject<HTMLDivElement>;
 }
 
 export const QuestionnaireDisplay: React.FC<QuestionnaireDisplayProps> = ({
   showRaw,
+  containerRef,
 }) => {
   const [editorValue, setEditorValue] = useState<string>("");
   const [parseError, setParseError] = useState<string | null>(null);
+
+  const editorRef = useRef<EditorView | null>(null);
+  const questionLineMap = useRef<Array<{ line: number; id: string }>>([]);
+  const prevShowRawRef = useRef(showRaw);
+  const scrollQuestionRef = useRef<string | null>(null);
 
   const {
     questionnaire,
@@ -47,7 +58,17 @@ export const QuestionnaireDisplay: React.FC<QuestionnaireDisplayProps> = ({
 
   useEffect(() => {
     if (questionnaire) {
-      setEditorValue(JSON.stringify(questionnaire, null, 2));
+      const json = JSON.stringify(questionnaire, null, 2);
+      setEditorValue(json);
+      const lines = json.split("\n");
+      const entries: Array<{ line: number; id: string }> = [];
+      lines.forEach((line, idx) => {
+        const match = line.match(/"id":\s*"([^"]+)"/);
+        if (match) {
+          entries.push({ line: idx + 1, id: match[1] });
+        }
+      });
+      questionLineMap.current = entries;
       setParseError(null);
     }
   }, [questionnaire]);
@@ -91,6 +112,91 @@ export const QuestionnaireDisplay: React.FC<QuestionnaireDisplayProps> = ({
     }
   };
 
+  const getTopQuestionFromFriendly = (): string | null => {
+    const container = containerRef.current;
+    if (!container) {
+      return null;
+    }
+    const questions = Array.from(
+      container.querySelectorAll<HTMLElement>(".question-item"),
+    );
+    const top = container.scrollTop;
+    for (const q of questions) {
+      if (q.offsetTop + q.offsetHeight > top) {
+        return q.dataset.questionId ?? null;
+      }
+    }
+    return null;
+  };
+
+  const scrollFriendlyToQuestion = (id: string) => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    const target = container.querySelector<HTMLElement>(
+      `.question-item[data-question-id="${id}"]`,
+    );
+    if (target) {
+      container.scrollTop = target.offsetTop;
+    }
+  };
+
+  const getTopQuestionFromRaw = (): string | null => {
+    if (!editorRef.current) {
+      return null;
+    }
+    const view = editorRef.current;
+    const block = view.lineBlockAtHeight(view.scrollDOM.scrollTop);
+    const lineNumber = view.state.doc.lineAt(block.from).number;
+    let current: string | null = null;
+    for (const entry of questionLineMap.current) {
+      if (entry.line <= lineNumber) {
+        current = entry.id;
+      } else {
+        break;
+      }
+    }
+    return current;
+  };
+
+  const scrollRawToQuestion = (id: string) => {
+    if (!editorRef.current) {
+      return;
+    }
+    const view = editorRef.current;
+    const entry = questionLineMap.current.find((e) => e.id === id);
+    if (!entry) {
+      return;
+    }
+    const pos = view.state.doc.line(entry.line).from;
+    const block = view.lineBlockAt(pos);
+    view.scrollDOM.scrollTop = block.top;
+  };
+
+  useEffect(() => {
+    if (prevShowRawRef.current !== showRaw) {
+      if (prevShowRawRef.current) {
+        scrollQuestionRef.current = getTopQuestionFromRaw();
+      } else {
+        scrollQuestionRef.current = getTopQuestionFromFriendly();
+      }
+      prevShowRawRef.current = showRaw;
+    }
+  }, [showRaw]);
+
+  useEffect(() => {
+    const id = scrollQuestionRef.current;
+    if (!id) {
+      return;
+    }
+    if (showRaw) {
+      scrollRawToQuestion(id);
+    } else {
+      scrollFriendlyToQuestion(id);
+    }
+  }, [showRaw]);
+
   return (
     <div className="questionnaire-display">
       {!showRaw && (
@@ -107,6 +213,9 @@ export const QuestionnaireDisplay: React.FC<QuestionnaireDisplayProps> = ({
           <CodeMirror
             value={editorValue}
             height="500px"
+            onCreateEditor={(view) => {
+              editorRef.current = view;
+            }}
             extensions={[
               gutter({ class: "CodeMirror-lint-markers" }),
               bracketMatching(),


### PR DESCRIPTION
## Summary
- keep scroll state in App `main-content` div
- track question IDs when switching between JSON and formatted views
- scroll to the corresponding question after toggling
- update tests for new `containerRef` prop

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `uv run python devtools/lint.py`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68586608d148832082c26d91f4a589a5