### PR TITLE
Add additional evals

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -32,6 +32,8 @@ The script prints a table with one row per case and an "Averages" row at the bot
   - `question_presence` (detecting question entries)
   - `question_type` (correct question types)
   - `option_extraction` (extracting choice options)
+  - `question_text` (correct question text)
+  - `question_section_grouping` (correct grouping of questions by section)
 - **Duration**: Time taken to process each case.
 
 **Metric definitions:**
@@ -99,11 +101,13 @@ Balanced trade-off—only high when both precision and recall are high.
 ## What is evaluated
 
 1. All sections and questions are present ✅
-2. Question types match expected types ✅
-3. Single/multi-select options are correctly extracted ✅
-4. Numeric sizes are correctly extracted 🔲
-5. Repeating sections are captured correctly 🔲
-6. Question ids, instructions and section descriptions are reasonable (LLM judge) 🔲
-7. Universe is reasonable (LLM judge) 🔲
-8. ID fields are correct 🔲
-9. Question ids are good (LLM judge) 🔲
+2. Question texts are correct ✅
+3. Question types match expected types ✅
+4. Single/multi-select options are correctly extracted ✅
+5. Questions are grouped by section correctly ✅
+6. Numeric sizes are correctly extracted 🔲
+7. Repeating sections are captured correctly 🔲
+8. Question ids, instructions and section descriptions are reasonable (LLM judge) 🔲
+9. Universe is reasonable (LLM judge) 🔲
+10. ID fields are correct 🔲
+11. Question ids are good (LLM judge) 🔲

--- a/evals/datasets/pdf_to_questionnaire_dataset.py
+++ b/evals/datasets/pdf_to_questionnaire_dataset.py
@@ -7,6 +7,8 @@ from evals.datasets.case_metadata import CaseMetadata
 from evals.evaluators.questionnaire_evaluators import (
     OptionExtractionEvaluator,
     QuestionPresenceEvaluator,
+    QuestionSectionGroupingEvaluator,
+    QuestionTextEvaluator,
     QuestionTypeEvaluator,
     SectionPresenceEvaluator,
 )
@@ -59,5 +61,7 @@ def load_dataset() -> Dataset[Path, Questionnaire, CaseMetadata]:
         evaluators=[SectionPresenceEvaluator(),
         QuestionPresenceEvaluator(),
         QuestionTypeEvaluator(),
+        QuestionTextEvaluator(),
+        QuestionSectionGroupingEvaluator(),
         OptionExtractionEvaluator(),
         ])

--- a/evals/evaluators/question_matcher.py
+++ b/evals/evaluators/question_matcher.py
@@ -1,0 +1,209 @@
+"""Question matching utilities for robust questionnaire comparison."""
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+
+from survaize.model.questionnaire import Question, Questionnaire
+
+logger = logging.getLogger(__name__)
+
+
+class MatchType(Enum):
+    """Types of question matches."""
+    NUMBER = "number"
+    ID = "id"
+    TEXT = "text"
+    FUZZY = "fuzzy"
+    POSITION = "position"
+
+
+@dataclass
+class QuestionMatch:
+    """Represents a matched question pair with confidence score."""
+    expected_idx: int
+    actual_idx: int
+    expected_question: Question
+    actual_question: Question
+    match_type: MatchType
+    confidence: float
+
+
+class QuestionMatcher:
+    """Matches questions between questionnaires using multiple strategies, ignoring section boundaries."""
+    
+    def __init__(self, similarity_threshold: float = 0.8) -> None:
+        self.similarity_threshold: float = similarity_threshold
+    
+    def match_questions(self, expected: Questionnaire, actual: Questionnaire) -> list[QuestionMatch]:
+        """Match questions globally across questionnaires, ignoring section boundaries."""
+        # Flatten all questions with global indices
+        expected_questions: list[Question] = []
+        for section in expected.sections:
+            expected_questions.extend(section.questions)
+        
+        actual_questions: list[Question] = []
+        for section in actual.sections:
+            actual_questions.extend(section.questions)
+        
+        matches: list[QuestionMatch] = []
+        used_actual: set[int] = set()
+        
+        # Level 1: Question number match (if both exist and are unique)
+        for exp_idx, exp_q in enumerate(expected_questions):
+            if exp_q.number and self._is_unique_number(exp_q.number, expected_questions):
+                for act_idx, act_q in enumerate(actual_questions):
+                    if (act_idx not in used_actual and 
+                        act_q.number == exp_q.number and 
+                        self._is_unique_number(act_q.number, actual_questions)):
+                        matches.append(QuestionMatch(
+                            exp_idx, act_idx, exp_q, act_q, MatchType.NUMBER, 1.0
+                        ))
+                        used_actual.add(act_idx)
+                        break
+        
+        # Level 2: Question ID match (if both exist and are unique)
+        matched_expected = {m.expected_idx for m in matches}
+        for exp_idx, exp_q in enumerate(expected_questions):
+            if (exp_idx not in matched_expected and 
+                exp_q.id and self._is_unique_id(exp_q.id, expected_questions)):
+                for act_idx, act_q in enumerate(actual_questions):
+                    if (act_idx not in used_actual and 
+                        act_q.id == exp_q.id and 
+                        self._is_unique_id(act_q.id, actual_questions)):
+                        matches.append(QuestionMatch(
+                            exp_idx, act_idx, exp_q, act_q, MatchType.ID, 0.9
+                        ))
+                        used_actual.add(act_idx)
+                        break
+        
+        # Level 3: Exact text match
+        matched_expected = {m.expected_idx for m in matches}
+        for exp_idx, exp_q in enumerate(expected_questions):
+            if exp_idx not in matched_expected:
+                for act_idx, act_q in enumerate(actual_questions):
+                    if (act_idx not in used_actual and 
+                        exp_q.text.strip() == act_q.text.strip()):
+                        matches.append(QuestionMatch(
+                            exp_idx, act_idx, exp_q, act_q, MatchType.TEXT, 0.8
+                        ))
+                        used_actual.add(act_idx)
+                        break
+        
+        # Level 4: Fuzzy text match
+        matched_expected = {m.expected_idx for m in matches}
+        for exp_idx, exp_q in enumerate(expected_questions):
+            if exp_idx not in matched_expected:
+                best_match = None
+                best_similarity = 0.0
+                
+                for act_idx, act_q in enumerate(actual_questions):
+                    if act_idx not in used_actual:
+                        similarity = self._text_similarity(exp_q.text, act_q.text)
+                        if similarity >= self.similarity_threshold and similarity > best_similarity:
+                            best_similarity = similarity
+                            best_match = (act_idx, act_q)
+                
+                if best_match:
+                    act_idx, act_q = best_match
+                    matches.append(QuestionMatch(
+                        exp_idx, act_idx, exp_q, act_q, MatchType.FUZZY, best_similarity * 0.7
+                    ))
+                    used_actual.add(act_idx)
+        
+        # Level 5: Position-based mapping for remaining questions
+        matched_expected = {m.expected_idx for m in matches}
+        unmatched_expected = [
+            (i, q) for i, q in enumerate(expected_questions) 
+            if i not in matched_expected
+        ]
+        unmatched_actual = [
+            (i, q) for i, q in enumerate(actual_questions) 
+            if i not in used_actual
+        ]
+        
+        # Match by relative position if we have similar numbers of unmatched questions
+        if unmatched_expected and unmatched_actual:
+            position_matches = self._position_based_matching(
+                unmatched_expected, unmatched_actual
+            )
+            
+            for exp_idx, act_idx, confidence in position_matches:
+                matches.append(QuestionMatch(
+                    exp_idx, act_idx, expected_questions[exp_idx], 
+                    actual_questions[act_idx], MatchType.POSITION, confidence
+                ))
+                used_actual.add(act_idx)
+
+        return matches
+    
+    def _text_similarity(self, text1: str, text2: str) -> float:
+        """Calculate text similarity using a simple approach based on common words."""
+        # Normalize texts
+        words1 = set(text1.lower().strip().split())
+        words2 = set(text2.lower().strip().split())
+        
+        # Remove common stop words that don't add meaning
+        stop_words = {
+            "the", "a", "an", "and", "or", "but", "in", "on", "at", "to", "for", "of", 
+            "with", "by", "is", "are", "was", "were", "what", "how", "when", "where", "why", "which"
+        }
+        words1 = words1 - stop_words
+        words2 = words2 - stop_words
+        
+        if not words1 or not words2:
+            return 0.0
+        
+        # Calculate Jaccard similarity
+        intersection = len(words1 & words2)
+        union = len(words1 | words2)
+        
+        return intersection / union if union > 0 else 0.0
+    
+    def _position_based_matching(
+        self, 
+        unmatched_expected: list[tuple[int, Question]], 
+        unmatched_actual: list[tuple[int, Question]]
+    ) -> list[tuple[int, int, float]]:
+        """Match questions based on their relative positions."""
+        matches: list[tuple[int, int, float]] = []
+        
+        # Simple greedy approach: match questions in order of their positions
+        min_len = min(len(unmatched_expected), len(unmatched_actual))
+        
+        for i in range(min_len):
+            exp_idx, exp_q = unmatched_expected[i]
+            act_idx, act_q = unmatched_actual[i]
+            
+            # Calculate confidence based on position alignment and question type similarity
+            confidence = 0.4  # Base confidence for position matching
+            
+            # Bonus if question types match
+            if exp_q.type == act_q.type:
+                confidence += 0.2
+            
+            # Small bonus for text similarity even if below threshold
+            text_sim = self._text_similarity(exp_q.text, act_q.text)
+            confidence += text_sim * 0.2
+            
+            # Cap confidence at reasonable level for position-based matching
+            confidence = min(confidence, 0.6)
+            
+            matches.append((exp_idx, act_idx, confidence))
+        
+        return matches
+    
+    def _is_unique_number(self, number: str, questions: list[Question]) -> bool:
+        """Check if a question number is unique within the question list."""
+        if not number or number.isspace():
+            return False
+        count = sum(1 for q in questions if q.number == number)
+        return count == 1
+    
+    def _is_unique_id(self, id_val: str, questions: list[Question]) -> bool:
+        """Check if a question ID is unique within the question list."""
+        if not id_val or id_val.isspace():
+            return False
+        count = sum(1 for q in questions if q.id == id_val)
+        return count == 1
+    

--- a/evals/evaluators/questionnaire_evaluators.py
+++ b/evals/evaluators/questionnaire_evaluators.py
@@ -7,35 +7,59 @@ from pydantic_evals.evaluators import Evaluator, EvaluatorContext
 from typing_extensions import override
 
 from evals.datasets.case_metadata import CaseMetadata
-from survaize.model.questionnaire import MultipleChoiceQuestion, Option, Questionnaire, Section, SingleChoiceQuestion
+from evals.evaluators.question_matcher import QuestionMatcher
+from evals.evaluators.section_matcher import SectionMatcher
+from survaize.model.questionnaire import MultipleChoiceQuestion, Question, Questionnaire, SingleChoiceQuestion
 
 logger = logging.getLogger(__name__)
+
 
 class SectionPresenceEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
     """Evaluator for checking that all expected sections are present."""
 
+    def __init__(self) -> None:
+        super().__init__()
+        self.section_matcher: SectionMatcher = SectionMatcher()
+
     @override
     def evaluate(self, ctx: EvaluatorContext[Path, Questionnaire, CaseMetadata]) -> dict[str, float]:
-        """Compute precision, recall, and F1 for section presence."""
+        """Compute precision, recall, and F1 for section presence using robust matching."""
         expected = ctx.expected_output
         assert expected is not None, "Expected output must not be None"
         actual: Questionnaire = ctx.output
 
-        expected_sections = {(section.number, section.title) for section in expected.sections}
-        actual_sections = {(section.number, section.title) for section in actual.sections}
-        true_positives = expected_sections & actual_sections
+        # Use the section matcher to find section correspondences
+        section_matches = self.section_matcher.match_sections(expected, actual)
+        
+        true_positives = len(section_matches)
+        total_expected = len(expected.sections)
+        total_actual = len(actual.sections)
 
-        precision = len(true_positives) / len(actual_sections) if actual_sections  else 0.0
-        recall = len(true_positives) / len(expected_sections) if expected_sections else 0.0
+        precision = true_positives / total_actual if total_actual else 0.0
+        recall = true_positives / total_expected if total_expected else 0.0
         f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
 
-        # log mismatches
-        missing = expected_sections - actual_sections
-        extra = actual_sections - expected_sections
-        if missing:
-            logger.warning(f"Missing sections: {missing}")
-        if extra:
-            logger.warning(f"Unexpected sections: {extra}")
+        # Log mismatches for debugging
+        matched_expected_indices = set(section_matches.keys())
+        matched_actual_indices = set(section_matches.values())
+        
+        missing_sections = [
+            f"Section {i}: ({expected.sections[i].number}, '{expected.sections[i].title}')"
+            for i in range(len(expected.sections))
+            if i not in matched_expected_indices
+        ]
+        
+        extra_sections = [
+            f"Section {i}: ({actual.sections[i].number}, '{actual.sections[i].title}')"
+            for i in range(len(actual.sections))
+            if i not in matched_actual_indices
+        ]
+        
+        if missing_sections:
+            logger.warning(f"Missing sections ({len(missing_sections)}): {missing_sections}")
+        if extra_sections:
+            logger.warning(f"Unexpected sections ({len(extra_sections)}): {extra_sections}")
+            
         return {
             "section_presence_precision": precision,
             "section_presence_recall": recall,
@@ -45,36 +69,65 @@ class SectionPresenceEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
 class QuestionPresenceEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
     """Evaluator for checking that all expected questions are present."""
 
+    def __init__(self) -> None:
+        super().__init__()
+        self.matcher: QuestionMatcher = QuestionMatcher()
+
     @override
     def evaluate(self, ctx: EvaluatorContext[Path, Questionnaire, CaseMetadata]) -> dict[str, float]:
-        """Compute precision, recall, and F1 for question presence."""
+        """Compute precision, recall, and F1 for question presence using robust matching."""
         expected = ctx.expected_output
         assert expected is not None, "Expected output must not be None"
         actual: Questionnaire = ctx.output
 
-        expected_questions = {
-            (section.number, question.number, question.text)
-            for section in expected.sections
-            for question in section.questions
-        }
-        actual_questions = {
-            (section.number, question.number, question.text)
-            for section in actual.sections
-            for question in section.questions
-        }
-        true_positives = expected_questions & actual_questions
+        # Get all questions flattened across sections
+        expected_questions: list[Question] = []
+        for section in expected.sections:
+            expected_questions.extend(section.questions)
+        
+        actual_questions: list[Question] = []
+        for section in actual.sections:
+            actual_questions.extend(section.questions)
 
-        precision = len(true_positives) / len(actual_questions) if actual_questions else 0.0
-        recall = len(true_positives) / len(expected_questions) if expected_questions else 0.0
+        # Use the matcher to find question correspondences
+        matches = self.matcher.match_questions(expected, actual)
+        
+        true_positives = len(matches)
+        total_expected = len(expected_questions)
+        total_actual = len(actual_questions)
+
+        precision = true_positives / total_actual if total_actual else 0.0
+        recall = true_positives / total_expected if total_expected else 0.0
         f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
 
-        # log mismatches
-        missing_q = expected_questions - actual_questions
-        extra_q = actual_questions - expected_questions
-        if missing_q:
-            logger.warning(f"Missing questions: {missing_q}")
-        if extra_q:
-            logger.warning(f"Unexpected questions: {extra_q}")
+        # Log mismatches for debugging
+        matched_expected_indices = {m.expected_idx for m in matches}
+        matched_actual_indices = {m.actual_idx for m in matches}
+        
+        missing_questions = [
+            f"Q{i}: {expected_questions[i].number or 'no_num'} - {expected_questions[i].text[:50]}..."
+            for i in range(len(expected_questions))
+            if i not in matched_expected_indices
+        ]
+        
+        extra_questions = [
+            f"Q{i}: {actual_questions[i].number or 'no_num'} - {actual_questions[i].text[:50]}..."
+            for i in range(len(actual_questions))
+            if i not in matched_actual_indices
+        ]
+        
+        if missing_questions:
+            logger.warning(f"Missing questions ({len(missing_questions)}): {missing_questions[:5]}...")
+        if extra_questions:
+            logger.warning(f"Unexpected questions ({len(extra_questions)}): {extra_questions[:5]}...")
+            
+        # Log match statistics
+        match_types: dict[str, int] = {}
+        for match in matches:
+            match_type_str = match.match_type.value
+            match_types[match_type_str] = match_types.get(match_type_str, 0) + 1
+        logger.info(f"Question match statistics: {match_types}")
+
         return {
             "question_presence_precision": precision,
             "question_presence_recall": recall,
@@ -83,6 +136,10 @@ class QuestionPresenceEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
 
 class QuestionTypeEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
     """Evaluator for checking that question types match the expected types."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.matcher: QuestionMatcher = QuestionMatcher()
 
     @override
     def evaluate(
@@ -93,33 +150,40 @@ class QuestionTypeEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
         assert expected is not None, "Expected output must not be None"
         actual: Questionnaire = ctx.output
 
-        # build maps keyed by (section_id, question_number) → QuestionType
-        expected_map = {
-            (sec.number, q.number): q.type
-            for sec in expected.sections
-            for q in sec.questions
-        }
-        actual_map = {
-            (sec.number, q.number): q.type
-            for sec in actual.sections
-            for q in sec.questions
-        }
+        # Get all questions flattened across sections
+        expected_questions: list[Question] = []
+        for section in expected.sections:
+            expected_questions.extend(section.questions)
+        
+        actual_questions: list[Question] = []
+        for section in actual.sections:
+            actual_questions.extend(section.questions)
 
-        # count how many actual types match expected types
-        matches = {
-            key for key, typ in actual_map.items()
-            if key in expected_map and expected_map[key] == typ
-        }
+        # Use the matcher to find question correspondences
+        matches = self.matcher.match_questions(expected, actual)
+        
+        # Count type matches among successfully matched questions
+        type_matches = 0
+        total_matches = len(matches)
+        
+        for match in matches:
+            if match.expected_question.type == match.actual_question.type:
+                type_matches += 1
+            else:
+                logger.warning(
+                    f"Type mismatch: {match.expected_question.number or match.expected_question.id} "
+                    + f"expected {match.expected_question.type}, got {match.actual_question.type}"
+                )
 
-        precision = len(matches) / len(actual_map) if actual_map else 0.0
-        recall = len(matches) / len(expected_map) if expected_map else 0.0
+        # For precision: how many of the actual questions that were matched have correct types
+        precision = type_matches / total_matches if total_matches else 0.0
+        
+        # For recall: how many of the expected questions were matched with correct types
+        total_expected = len(expected_questions)
+        recall = type_matches / total_expected if total_expected else 0.0
+        
         f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
 
-        # log type mismatches
-        mismatches = [key for key in expected_map if key in actual_map and expected_map[key] != actual_map[key]]
-        for sec_q in mismatches:
-            exp, act = expected_map[sec_q], actual_map[sec_q]
-            logger.warning(f"Type mismatch at {sec_q}: expected {exp}, got {act}")
         return {
             "question_type_precision": precision,
             "question_type_recall": recall,
@@ -130,6 +194,10 @@ class QuestionTypeEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
 class OptionExtractionEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
     """Evaluator for checking that select‐question options are correctly extracted."""
 
+    def __init__(self) -> None:
+        super().__init__()
+        self.matcher: QuestionMatcher = QuestionMatcher()
+
     @override
     def evaluate(
         self,
@@ -139,34 +207,217 @@ class OptionExtractionEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
         assert expected is not None, "Expected output must not be None"
         actual: Questionnaire = ctx.output
 
-        def collect_options(qs: list[Section]) -> dict[tuple[str, str], list[Option]]:
-            # returns mapping (section_number, question_number) → set of option labels
-            return {
-                (sec.number, q.number): q.options
-                for sec in qs
-                for q in sec.questions
-                if isinstance(q, SingleChoiceQuestion | MultipleChoiceQuestion)
-            }
+        # Use the matcher to find question correspondences
+        matches = self.matcher.match_questions(expected, actual)
+        
+        # Filter matches to only include select questions and count option matches
+        option_matches = 0
+        total_select_matches = 0
+        
+        for match in matches:
+            exp_q = match.expected_question
+            act_q = match.actual_question
+            
+            # Only evaluate option extraction for select questions
+            if isinstance(exp_q, SingleChoiceQuestion | MultipleChoiceQuestion):
+                total_select_matches += 1
+                
+                # Check if actual question is also a select question
+                if isinstance(act_q, SingleChoiceQuestion | MultipleChoiceQuestion):
+                    # Compare options lists
+                    if exp_q.options == act_q.options:
+                        option_matches += 1
+                    else:
+                        # Format options more readably
+                        exp_opts = "\n    - " + "\n    - ".join(
+                            str(opt) for opt in exp_q.options
+                        ) if exp_q.options else "[]"
+                        act_opts = "\n    - " + "\n    - ".join(
+                            str(opt) for opt in act_q.options
+                        ) if act_q.options else "[]"
+                        
+                        logger.warning(
+                            f"Option mismatch for {exp_q.number or exp_q.id}:\n" +
+                            f"Expected options:{exp_opts}\n" +
+                            f"Actual options:{act_opts}"
+                        )
+                else:
+                    logger.warning(
+                        f"Type mismatch for select question {exp_q.number or exp_q.id}: "
+                        + f"expected select question, got {act_q.type}"
+                    )
 
-        expected_opts = collect_options(expected.sections)
-        actual_opts = collect_options(actual.sections)
-
-        # count how many actual option‐sets exactly match expected
-        matches = {
-            key for key, opts in actual_opts.items()
-            if key in expected_opts and expected_opts[key] == opts
-        }
-
-        precision = len(matches) / len(actual_opts) if actual_opts else 0.0
-        recall = len(matches) / len(expected_opts) if expected_opts else 0.0
+        # Calculate metrics based on successfully matched select questions
+        precision = option_matches / total_select_matches if total_select_matches else 0.0
+        
+        # For recall, count all expected select questions
+        total_expected_select = sum(
+            1 for section in expected.sections
+            for question in section.questions
+            if isinstance(question, SingleChoiceQuestion | MultipleChoiceQuestion)
+        )
+        
+        recall = option_matches / total_expected_select if total_expected_select else 0.0
         f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
 
-        # log option mismatches
-        for key, opts in actual_opts.items():
-            if key in expected_opts and expected_opts[key] != opts:
-                logger.warning(f"Option mismatch at {key}: expected {expected_opts[key]}, got {opts}")
         return {
             "option_extraction_precision": precision,
             "option_extraction_recall": recall,
             "option_extraction_f1": f1,
+        }
+
+
+class QuestionTextEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
+    """Evaluator for checking that question text fields are an exact match."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.matcher: QuestionMatcher = QuestionMatcher()
+
+    @override
+    def evaluate(
+        self,
+        ctx: EvaluatorContext[Path, Questionnaire, CaseMetadata]
+    ) -> dict[str, float]:
+        """Compute precision, recall, and F1 for exact question text matches."""
+        expected = ctx.expected_output
+        assert expected is not None, "Expected output must not be None"
+        actual: Questionnaire = ctx.output
+
+        # Get all questions flattened across sections
+        expected_questions: list[Question] = []
+        for section in expected.sections:
+            expected_questions.extend(section.questions)
+        
+        actual_questions: list[Question] = []
+        for section in actual.sections:
+            actual_questions.extend(section.questions)
+
+        # Use the matcher to find question correspondences
+        matches = self.matcher.match_questions(expected, actual)
+        
+        # Count exact text matches among successfully matched questions
+        text_matches = 0
+        total_matches = len(matches)
+        
+        for match in matches:
+            if match.expected_question.text == match.actual_question.text:
+                text_matches += 1
+            else:
+                logger.warning(
+                    f"Text mismatch for {match.expected_question.number or match.expected_question.id}: "
+                    + f"expected '{match.expected_question.text}', "
+                    + f"got '{match.actual_question.text}'"
+                )
+
+        # For precision: how many of the actual questions that were matched have exact text
+        precision = text_matches / total_matches if total_matches else 0.0
+        
+        # For recall: how many of the expected questions were matched with exact text
+        total_expected = len(expected_questions)
+        recall = text_matches / total_expected if total_expected else 0.0
+        
+        f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
+
+        return {
+            "question_text_precision": precision,
+            "question_text_recall": recall,
+            "question_text_f1": f1,
+        }
+
+
+class QuestionSectionGroupingEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
+    """Evaluator for checking that questions are correctly grouped into their expected sections."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.matcher: QuestionMatcher = QuestionMatcher()
+        self.section_matcher: SectionMatcher = SectionMatcher()
+
+    @override
+    def evaluate(
+        self,
+        ctx: EvaluatorContext[Path, Questionnaire, CaseMetadata]
+    ) -> dict[str, float]:
+        """Compute precision, recall, and F1 for correct question section grouping."""
+        expected = ctx.expected_output
+        assert expected is not None, "Expected output must not be None"
+        actual: Questionnaire = ctx.output
+
+        # First, match sections between expected and actual questionnaires
+        section_matches = self.section_matcher.match_sections(expected, actual)
+        
+        # Build mappings from question flat index to matched section index
+        expected_question_to_section_idx: dict[int, int] = {}
+        flat_idx = 0
+        for section_idx, section in enumerate(expected.sections):
+            for _ in section.questions:
+                expected_question_to_section_idx[flat_idx] = section_idx
+                flat_idx += 1
+
+        actual_question_to_section_idx: dict[int, int] = {}
+        flat_idx = 0
+        for section_idx, section in enumerate(actual.sections):
+            for _ in section.questions:
+                actual_question_to_section_idx[flat_idx] = section_idx
+                flat_idx += 1
+
+        # Use the question matcher to find question correspondences
+        matches = self.matcher.match_questions(expected, actual)
+        
+        # Count correct section groupings among successfully matched questions
+        correct_groupings = 0
+        total_matches = len(matches)
+        
+        for match in matches:
+            # Get section indices for both questions
+            expected_section_idx = expected_question_to_section_idx.get(match.expected_idx)
+            actual_section_idx = actual_question_to_section_idx.get(match.actual_idx)
+            
+            if expected_section_idx is not None and actual_section_idx is not None:
+                # Check if the actual section matches the expected section
+                expected_matched_section_idx = section_matches.get(expected_section_idx)
+                
+                if expected_matched_section_idx == actual_section_idx:
+                    correct_groupings += 1
+                else:
+                    # Log the mismatch with section details
+                    question_id = match.expected_question.number or match.expected_question.id
+                    exp_section = expected.sections[expected_section_idx]
+                    act_section = actual.sections[actual_section_idx]
+                    
+                    if expected_matched_section_idx is not None:
+                        expected_matched_section = actual.sections[expected_matched_section_idx]
+                        logger.warning(
+                            f"Section grouping mismatch for question {question_id}: "
+                            + f"expected in section ({exp_section.number}, '{exp_section.title}') "
+                            + f"which matches actual section ({expected_matched_section.number}, "
+                            + f"'{expected_matched_section.title}'), "
+                            + f"but found in section ({act_section.number}, '{act_section.title}')"
+                        )
+                    else:
+                        logger.warning(
+                            f"Section grouping mismatch for question {question_id}: "
+                            + f"expected section ({exp_section.number}, '{exp_section.title}') has no match, "
+                            + f"but question found in section ({act_section.number}, '{act_section.title}')"
+                        )
+            else:
+                question_id = match.expected_question.number or match.expected_question.id
+                logger.warning(
+                    f"Could not determine section for question {question_id}"
+                )
+
+        # For precision: how many of the matched questions are in the correct section
+        precision = correct_groupings / total_matches if total_matches else 0.0
+        
+        # For recall: how many of the expected questions were matched and placed in correct sections
+        total_expected_questions = sum(len(section.questions) for section in expected.sections)
+        recall = correct_groupings / total_expected_questions if total_expected_questions else 0.0
+        
+        f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
+
+        return {
+            "question_section_grouping_precision": precision,
+            "question_section_grouping_recall": recall,
+            "question_section_grouping_f1": f1,
         }

--- a/evals/evaluators/section_matcher.py
+++ b/evals/evaluators/section_matcher.py
@@ -1,0 +1,73 @@
+"""Section matching utilities for questionnaire evaluation."""
+
+from dataclasses import dataclass
+
+from survaize.model.questionnaire import Questionnaire, Section
+
+
+@dataclass
+class SectionMatch:
+    """Represents a matched section pair."""
+    expected_idx: int
+    actual_idx: int
+    expected_section: Section
+    actual_section: Section
+    match_type: str
+    confidence: float
+
+
+class SectionMatcher:
+    """Simple matcher for sections using number, title, and position."""
+    
+    def match_sections(self, expected: Questionnaire, actual: Questionnaire) -> dict[int, int]:
+        """
+        Match sections between questionnaires.
+        Returns a mapping from expected section index to actual section index.
+        """
+        expected_sections = expected.sections
+        actual_sections = actual.sections
+        
+        section_matches: dict[int, int] = {}
+        used_actual: set[int] = set()
+        
+        # Level 1: Exact number and title match
+        for exp_idx, exp_section in enumerate(expected_sections):
+            for act_idx, act_section in enumerate(actual_sections):
+                if (act_idx not in used_actual and
+                    exp_section.number == act_section.number and
+                    exp_section.title == act_section.title):
+                    section_matches[exp_idx] = act_idx
+                    used_actual.add(act_idx)
+                    break
+        
+        # Level 2: Number match only (if unique)
+        for exp_idx, exp_section in enumerate(expected_sections):
+            if (exp_idx not in section_matches and
+                sum(1 for s in expected_sections if s.number == exp_section.number) == 1):
+                for act_idx, act_section in enumerate(actual_sections):
+                    if (act_idx not in used_actual and
+                        act_section.number == exp_section.number and
+                        sum(1 for s in actual_sections if s.number == act_section.number) == 1):
+                        section_matches[exp_idx] = act_idx
+                        used_actual.add(act_idx)
+                        break
+        
+        # Level 3: Title match only (if reasonably unique)
+        for exp_idx, exp_section in enumerate(expected_sections):
+            if exp_idx not in section_matches:
+                for act_idx, act_section in enumerate(actual_sections):
+                    if (act_idx not in used_actual and
+                        exp_section.title.strip().lower() == act_section.title.strip().lower()):
+                        section_matches[exp_idx] = act_idx
+                        used_actual.add(act_idx)
+                        break
+        
+        # Level 4: Position-based fallback
+        for exp_idx, _ in enumerate(expected_sections):
+            if (exp_idx not in section_matches and
+                exp_idx < len(actual_sections) and 
+                exp_idx not in used_actual):
+                section_matches[exp_idx] = exp_idx
+                used_actual.add(exp_idx)
+        
+        return section_matches

--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import logfire
 from dotenv import load_dotenv
 
 from evals.datasets.pdf_to_questionnaire_dataset import load_dataset
@@ -10,6 +11,13 @@ from survaize.reader.pdf_reader import PDFReader
 
 load_dotenv()
 config = create_llm_config_from_env()
+
+logfire.configure(
+    send_to_logfire='if-token-present',  
+    environment='development',  
+    service_name='evals',  
+)
+logfire.instrument_openai()
 
 async def convert_questionnaire(pdf_path: Path) -> Questionnaire:
 


### PR DESCRIPTION
This pull request introduces enhancements to questionnaire evaluation, including new evaluators, utilities for matching questions and sections, and improved logging configuration. The changes aim to improve the accuracy and robustness of questionnaire processing and evaluation.

### Enhancements to Questionnaire Evaluation:

* **New Evaluators Added**:
  - Added `QuestionTextEvaluator` and `QuestionSectionGroupingEvaluator` to evaluate the correctness of question text and grouping by section. (`evals/datasets/pdf_to_questionnaire_dataset.py`, [[1]](diffhunk://#diff-d75c9b3ea67808789676a456a527a7a3432c23c5b061b33fed1e05829f17d971R10-R11) [[2]](diffhunk://#diff-d75c9b3ea67808789676a456a527a7a3432c23c5b061b33fed1e05829f17d971R64-R65)
  - Updated evaluation metrics in `evals/README.md` to include these new criteria. [[1]](diffhunk://#diff-a1a9eeb43d4de7693b860e126cdd7ffd4a8f6f8264f084a451b684cf143a86dcR35-R36) [[2]](diffhunk://#diff-a1a9eeb43d4de7693b860e126cdd7ffd4a8f6f8264f084a451b684cf143a86dcL102-R113)

* **Question Matching Utility**:
  - Introduced `QuestionMatcher` class to match questions between expected and actual questionnaires using strategies such as number, ID, text, fuzzy text, and position-based matching. (`evals/evaluators/question_matcher.py`, [evals/evaluators/question_matcher.pyR1-R209](diffhunk://#diff-06c7a4d8306b9ef394726191aeffa96f40001d74be014753e537634939ee9a20R1-R209))

* **Section Matching Utility**:
  - Added `SectionMatcher` class to match sections based on number, title, and position, ensuring accurate section comparison in questionnaires. (`evals/evaluators/section_matcher.py`, [evals/evaluators/section_matcher.pyR1-R73](diffhunk://#diff-48ed4835d0b809a13169cdc854db6c30d2afb5abc50846f0fee8c073b29519aeR1-R73))

### Logging Improvements:

* **Logfire Integration**:
  - Configured `logfire` for improved logging and monitoring of the evaluation process, including instrumentation for OpenAI services. (`evals/run_evals.py`, [[1]](diffhunk://#diff-f77d13383490ecbc07efa488bb0a5af5d4e1c206c413caff23aaa749ee0ec8a5R3) [[2]](diffhunk://#diff-f77d13383490ecbc07efa488bb0a5af5d4e1c206c413caff23aaa749ee0ec8a5R15-R21)