### PR TITLE
Add option to skip OCR when reading PDFs

### DIFF
--- a/src/survaize/interpreter/ai_interpreter.py
+++ b/src/survaize/interpreter/ai_interpreter.py
@@ -78,7 +78,8 @@ class AIQuestionnaireInterpreter:
         """Interpret a questionnaire document into a structured format.
 
         Args:
-            scanned_document: QuestionnaireDocument containing page images and OCR text
+            scanned_document: QuestionnaireDocument containing page images. The
+                OCR text may be omitted.
 
         Returns:
             Structured Questionnaire object
@@ -91,8 +92,11 @@ class AIQuestionnaireInterpreter:
         total_usage = LLMUsage()
 
         context: list[SectionFragment] = []
+        texts = (
+            scanned_document.extracted_text if scanned_document.extracted_text else ["" for _ in scanned_document.pages]
+        )
         for i, (page, text) in enumerate(
-            zip(scanned_document.pages, scanned_document.extracted_text, strict=False),
+            zip(scanned_document.pages, texts, strict=True),
             1,
         ):
             if progress_callback:

--- a/src/survaize/reader/pdf_reader.py
+++ b/src/survaize/reader/pdf_reader.py
@@ -21,15 +21,21 @@ logger = logging.getLogger(__name__)
 
 
 class PDFReader:
-    """Reads PDF documents and extracts text and images."""
+    """Reads PDF documents and optionally performs OCR extraction."""
 
-    def __init__(self, interpreter: AIQuestionnaireInterpreter):
+    def __init__(
+        self,
+        interpreter: AIQuestionnaireInterpreter,
+        capture_ocr: bool = True,
+    ) -> None:
         """Initialize the PDFReader with an interpreter.
 
         Args:
             interpreter: An instance of AIQuestionnaireInterpreter
+            capture_ocr: Flag indicating whether OCR text should be captured.
         """
         self.interpreter: AIQuestionnaireInterpreter = interpreter
+        self.capture_ocr: bool = capture_ocr
 
     @logfire.instrument(extract_args=False)
     def read(
@@ -43,7 +49,8 @@ class PDFReader:
             file: File-like object containing the PDF
 
         Returns:
-            A Questionnaire containing the extracted content
+            A Questionnaire containing the extracted content. When
+            ``capture_ocr`` is ``False`` no OCR text is returned.
         """
 
         if progress_callback:
@@ -51,16 +58,18 @@ class PDFReader:
         pages = self._extract_pages(file)
         if progress_callback:
             progress_callback(1, f"Extracted {len(pages)} pages")
+
         texts: list[str] = []
-        for i, page in enumerate(pages, start=1):
-            if progress_callback:
-                percent = int(10 * (i - 1) / len(pages))
-                progress_callback(percent, f"Extracting image from page {i}/{len(pages)}")
-            texts.append(self._process_page(page))
+        if self.capture_ocr:
+            for i, page in enumerate(pages, start=1):
+                if progress_callback:
+                    percent = int(10 * (i - 1) / len(pages))
+                    progress_callback(percent, f"Extracting image from page {i}/{len(pages)}")
+                texts.append(self._process_page(page))
 
         scanned_questionnaire = ScannedQuestionnaire(
             pages=pages,
-            extracted_text=texts,
+            extracted_text=texts if self.capture_ocr else [],
             source_path=Path("<in-memory>"),
         )
 

--- a/tests/test_ai_interpreter.py
+++ b/tests/test_ai_interpreter.py
@@ -185,3 +185,27 @@ def test_interpret_logs_usage(
         interpreter.interpret(mock_document)
 
         assert any("Token usage - prompt: 3" in r.getMessage() and "total: 7" in r.getMessage() for r in caplog.records)
+
+
+def test_interpret_without_ocr_text(mock_document: ScannedQuestionnaire, mock_llm_config: LLMConfig) -> None:
+    """Verify interpret works when OCR text is not provided."""
+    with patch("survaize.interpreter.ai_interpreter.create_openai_client") as mock_factory:
+        mock_client = MagicMock()
+        mock_factory.return_value = mock_client
+
+        completion = MagicMock()
+        completion.choices[0].message.content = json.dumps(
+            {"title": "Test Survey", "id_fields": ["id"], "sections": [], "trailing_sections": []}
+        )
+        mock_client.chat.completions.create.return_value = completion
+
+        interpreter = AIQuestionnaireInterpreter(mock_llm_config)
+        doc = ScannedQuestionnaire(
+            pages=mock_document.pages,
+            extracted_text=[],
+            source_path=mock_document.source_path,
+        )
+
+        result = interpreter.interpret(doc)
+
+        assert isinstance(result, Questionnaire)

--- a/tests/test_pdf_reader.py
+++ b/tests/test_pdf_reader.py
@@ -1,0 +1,27 @@
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+from PIL import Image
+
+from survaize.interpreter.ai_interpreter import AIQuestionnaireInterpreter
+from survaize.model.questionnaire import Questionnaire
+from survaize.reader.pdf_reader import PDFReader
+
+
+def test_pdf_reader_without_ocr() -> None:
+    interpreter = MagicMock(spec=AIQuestionnaireInterpreter)
+    interpreter.interpret.return_value = Questionnaire(
+        title="Survey",
+        description=None,
+        id_fields=[],
+        sections=[],
+        trailing_sections=[],
+    )
+    reader = PDFReader(interpreter, capture_ocr=False)
+    img = Image.new("RGB", (10, 10), "white")
+    with patch.object(PDFReader, "_extract_pages", return_value=[img]):
+        questionnaire = reader.read(BytesIO(b"pdf"))
+
+    scanned_doc = interpreter.interpret.call_args.args[0]
+    assert scanned_doc.extracted_text == []
+    assert isinstance(questionnaire, Questionnaire)


### PR DESCRIPTION
## Summary
- allow `PDFReader` to skip OCR extraction via new `capture_ocr` flag
- handle questionnaires with missing OCR text in `AIQuestionnaireInterpreter`
- test interpreting without OCR text
- add regression test for `PDFReader` with OCR disabled

## Testing
- `uv run python devtools/lint.py`
- `uv run pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_686fbcd1400c8320ac979793223a7895