### PR TITLE
Expand lint coverage to evals

### DIFF
--- a/devtools/lint.py
+++ b/devtools/lint.py
@@ -5,7 +5,7 @@ from rich import get_console, reconfigure
 from rich import print as rprint
 
 # Update as needed.
-SRC_PATHS = ["src", "tests", "devtools"]
+SRC_PATHS = ["src", "tests", "devtools", "evals"]
 DOC_PATHS = ["README.md"]
 
 

--- a/evals/datasets/case_metadata.py
+++ b/evals/datasets/case_metadata.py
@@ -6,7 +6,8 @@ from survaize.model.questionnaire import QuestionType
 @dataclass
 class CaseMetadata:
     """Metadata for a case."""
-    difficulty: int # scale of 1 to 5
+
+    difficulty: int  # scale of 1 to 5
     pages: int
     sections: int
     questions: int

--- a/evals/datasets/pdf_to_questionnaire_dataset.py
+++ b/evals/datasets/pdf_to_questionnaire_dataset.py
@@ -1,4 +1,3 @@
-
 from pathlib import Path
 
 from pydantic_evals import Case, Dataset
@@ -23,7 +22,6 @@ def _create_case(
     ground_truth_json_path: Path,
     metadata: CaseMetadata,
 ) -> Case[Path, Questionnaire, CaseMetadata]:
-
     with open(ground_truth_json_path, "rb") as f:
         ground_truth_json = JSONReader().read(f)
     return Case(
@@ -33,16 +31,16 @@ def _create_case(
         metadata=metadata,
     )
 
-def load_dataset() -> Dataset[Path, Questionnaire, CaseMetadata]:
 
+def load_dataset() -> Dataset[Path, Questionnaire, CaseMetadata]:
     # Create cases for all questionnaires
     cases: list[Case[Path, Questionnaire, CaseMetadata]] = []
-    
+
     # Popstan Household Survey
     base_path = EXAMPLES_DIR / "PopstanHouseholdSurvey"
     pdf_path = base_path / "PopstanHouseholdQuestionnaire.pdf"
     json_path = base_path / "PopstanHouseholdQuestionnaire.json"
-    
+
     popstan_case = _create_case(
         name="popstan_household_survey",
         input_path=pdf_path,
@@ -52,8 +50,13 @@ def load_dataset() -> Dataset[Path, Questionnaire, CaseMetadata]:
             pages=4,
             sections=4,
             questions=24,
-            question_types=[QuestionType.NUMERIC, QuestionType.TEXT, QuestionType.SINGLE_SELECT, 
-                QuestionType.MULTI_SELECT, QuestionType.DATE],
+            question_types=[
+                QuestionType.NUMERIC,
+                QuestionType.TEXT,
+                QuestionType.SINGLE_SELECT,
+                QuestionType.MULTI_SELECT,
+                QuestionType.DATE,
+            ],
         ),
     )
     cases.append(popstan_case)
@@ -62,7 +65,7 @@ def load_dataset() -> Dataset[Path, Questionnaire, CaseMetadata]:
     base_path = EXAMPLES_DIR / "Japan National Survey of Family Income 2019"
     pdf_path = base_path / "JapanNationalSurveyFamilyIncome2019.pdf"
     json_path = base_path / "JapanNationalSurveyFamilyIncome2019.json"
-    
+
     japan_case = _create_case(
         name="japan_national_survey_family_income_2019",
         input_path=pdf_path,
@@ -73,8 +76,10 @@ def load_dataset() -> Dataset[Path, Questionnaire, CaseMetadata]:
             sections=10,
             questions=47,
             question_types=[
-                QuestionType.MULTI_SELECT, QuestionType.NUMERIC, 
-                QuestionType.SINGLE_SELECT, QuestionType.TEXT
+                QuestionType.MULTI_SELECT,
+                QuestionType.NUMERIC,
+                QuestionType.SINGLE_SELECT,
+                QuestionType.TEXT,
             ],
         ),
     )
@@ -84,7 +89,7 @@ def load_dataset() -> Dataset[Path, Questionnaire, CaseMetadata]:
     base_path = EXAMPLES_DIR / "Slovenia Census Questionnaire for Dwellings 2002"
     pdf_path = base_path / "SloveniaCensusQuestionnaireDwellings2002.pdf"
     json_path = base_path / "SloveniaCensusQuestionnaireDwellings2002.json"
-    
+
     slovenia_case = _create_case(
         name="slovenia_census_questionnaire_dwellings_2002",
         input_path=pdf_path,
@@ -95,8 +100,10 @@ def load_dataset() -> Dataset[Path, Questionnaire, CaseMetadata]:
             sections=2,
             questions=41,
             question_types=[
-                QuestionType.MULTI_SELECT, QuestionType.NUMERIC, 
-                QuestionType.SINGLE_SELECT, QuestionType.TEXT
+                QuestionType.MULTI_SELECT,
+                QuestionType.NUMERIC,
+                QuestionType.SINGLE_SELECT,
+                QuestionType.TEXT,
             ],
         ),
     )
@@ -106,7 +113,7 @@ def load_dataset() -> Dataset[Path, Questionnaire, CaseMetadata]:
     base_path = EXAMPLES_DIR / "Rwanda Population and Housing Census 2022"
     pdf_path = base_path / "RwandaPHC2022_HH_Questionnaire.pdf"
     json_path = base_path / "RwandaPHC2022_HH_Questionnaire.json"
-    
+
     rwanda_case = _create_case(
         name="rwanda_phc_2022_hh_questionnaire",
         input_path=pdf_path,
@@ -116,8 +123,13 @@ def load_dataset() -> Dataset[Path, Questionnaire, CaseMetadata]:
             pages=10,
             sections=5,
             questions=155,
-            question_types=[QuestionType.LOCATION, QuestionType.MULTI_SELECT, QuestionType.NUMERIC, 
-                QuestionType.SINGLE_SELECT, QuestionType.TEXT],
+            question_types=[
+                QuestionType.LOCATION,
+                QuestionType.MULTI_SELECT,
+                QuestionType.NUMERIC,
+                QuestionType.SINGLE_SELECT,
+                QuestionType.TEXT,
+            ],
         ),
     )
     cases.append(rwanda_case)
@@ -126,7 +138,7 @@ def load_dataset() -> Dataset[Path, Questionnaire, CaseMetadata]:
     base_path = EXAMPLES_DIR / "World Bank COVID-19 Impact on Firms"
     pdf_path = base_path / "WorldBankCOVID19ImpactFirms.pdf"
     json_path = base_path / "WorldBankCOVID19ImpactFirms.json"
-    
+
     world_bank_case = _create_case(
         name="world_bank_covid19_impact_firms",
         input_path=pdf_path,
@@ -141,11 +153,14 @@ def load_dataset() -> Dataset[Path, Questionnaire, CaseMetadata]:
     )
     cases.append(world_bank_case)
 
-    return Dataset(cases=cases, 
-        evaluators=[SectionPresenceEvaluator(),
-        QuestionPresenceEvaluator(),
-        QuestionTypeEvaluator(),
-        QuestionTextEvaluator(),
-        QuestionSectionGroupingEvaluator(),
-        OptionExtractionEvaluator(),
-        ])
+    return Dataset(
+        cases=cases,
+        evaluators=[
+            SectionPresenceEvaluator(),
+            QuestionPresenceEvaluator(),
+            QuestionTypeEvaluator(),
+            QuestionTextEvaluator(),
+            QuestionSectionGroupingEvaluator(),
+            OptionExtractionEvaluator(),
+        ],
+    )

--- a/evals/evaluators/question_matcher.py
+++ b/evals/evaluators/question_matcher.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 
 class MatchType(Enum):
     """Types of question matches."""
+
     NUMBER = "number"
     ID = "id"
     TEXT = "text"
@@ -21,6 +22,7 @@ class MatchType(Enum):
 @dataclass
 class QuestionMatch:
     """Represents a matched question pair with confidence score."""
+
     expected_idx: int
     actual_idx: int
     expected_question: Question
@@ -31,179 +33,192 @@ class QuestionMatch:
 
 class QuestionMatcher:
     """Matches questions between questionnaires using multiple strategies, ignoring section boundaries."""
-    
+
     def __init__(self, similarity_threshold: float = 0.8) -> None:
         self.similarity_threshold: float = similarity_threshold
-    
+
     def match_questions(self, expected: Questionnaire, actual: Questionnaire) -> list[QuestionMatch]:
         """Match questions globally across questionnaires, ignoring section boundaries."""
         # Flatten all questions with global indices
         expected_questions: list[Question] = []
         for section in expected.sections:
             expected_questions.extend(section.questions)
-        
+
         actual_questions: list[Question] = []
         for section in actual.sections:
             actual_questions.extend(section.questions)
-        
+
         matches: list[QuestionMatch] = []
         used_actual: set[int] = set()
-        
+
         # Level 1: Question number match (if both exist and are unique)
         for exp_idx, exp_q in enumerate(expected_questions):
             if exp_q.number and self._is_unique_number(exp_q.number, expected_questions):
                 for act_idx, act_q in enumerate(actual_questions):
-                    if (act_idx not in used_actual and 
-                        act_q.number == exp_q.number and 
-                        self._is_unique_number(act_q.number, actual_questions)):
-                        matches.append(QuestionMatch(
-                            exp_idx, act_idx, exp_q, act_q, MatchType.NUMBER, 1.0
-                        ))
+                    if (
+                        act_idx not in used_actual
+                        and act_q.number == exp_q.number
+                        and self._is_unique_number(act_q.number, actual_questions)
+                    ):
+                        matches.append(QuestionMatch(exp_idx, act_idx, exp_q, act_q, MatchType.NUMBER, 1.0))
                         used_actual.add(act_idx)
                         break
-        
+
         # Level 2: Question ID match (if both exist and are unique)
         matched_expected = {m.expected_idx for m in matches}
         for exp_idx, exp_q in enumerate(expected_questions):
-            if (exp_idx not in matched_expected and 
-                exp_q.id and self._is_unique_id(exp_q.id, expected_questions)):
+            if exp_idx not in matched_expected and exp_q.id and self._is_unique_id(exp_q.id, expected_questions):
                 for act_idx, act_q in enumerate(actual_questions):
-                    if (act_idx not in used_actual and 
-                        act_q.id == exp_q.id and 
-                        self._is_unique_id(act_q.id, actual_questions)):
-                        matches.append(QuestionMatch(
-                            exp_idx, act_idx, exp_q, act_q, MatchType.ID, 0.9
-                        ))
+                    if (
+                        act_idx not in used_actual
+                        and act_q.id == exp_q.id
+                        and self._is_unique_id(act_q.id, actual_questions)
+                    ):
+                        matches.append(QuestionMatch(exp_idx, act_idx, exp_q, act_q, MatchType.ID, 0.9))
                         used_actual.add(act_idx)
                         break
-        
+
         # Level 3: Exact text match
         matched_expected = {m.expected_idx for m in matches}
         for exp_idx, exp_q in enumerate(expected_questions):
             if exp_idx not in matched_expected:
                 for act_idx, act_q in enumerate(actual_questions):
-                    if (act_idx not in used_actual and 
-                        exp_q.text.strip() == act_q.text.strip()):
-                        matches.append(QuestionMatch(
-                            exp_idx, act_idx, exp_q, act_q, MatchType.TEXT, 0.8
-                        ))
+                    if act_idx not in used_actual and exp_q.text.strip() == act_q.text.strip():
+                        matches.append(QuestionMatch(exp_idx, act_idx, exp_q, act_q, MatchType.TEXT, 0.8))
                         used_actual.add(act_idx)
                         break
-        
+
         # Level 4: Fuzzy text match
         matched_expected = {m.expected_idx for m in matches}
         for exp_idx, exp_q in enumerate(expected_questions):
             if exp_idx not in matched_expected:
                 best_match = None
                 best_similarity = 0.0
-                
+
                 for act_idx, act_q in enumerate(actual_questions):
                     if act_idx not in used_actual:
                         similarity = self._text_similarity(exp_q.text, act_q.text)
                         if similarity >= self.similarity_threshold and similarity > best_similarity:
                             best_similarity = similarity
                             best_match = (act_idx, act_q)
-                
+
                 if best_match:
                     act_idx, act_q = best_match
-                    matches.append(QuestionMatch(
-                        exp_idx, act_idx, exp_q, act_q, MatchType.FUZZY, best_similarity * 0.7
-                    ))
+                    matches.append(
+                        QuestionMatch(exp_idx, act_idx, exp_q, act_q, MatchType.FUZZY, best_similarity * 0.7)
+                    )
                     used_actual.add(act_idx)
-        
+
         # Level 5: Position-based mapping for remaining questions
         matched_expected = {m.expected_idx for m in matches}
-        unmatched_expected = [
-            (i, q) for i, q in enumerate(expected_questions) 
-            if i not in matched_expected
-        ]
-        unmatched_actual = [
-            (i, q) for i, q in enumerate(actual_questions) 
-            if i not in used_actual
-        ]
-        
+        unmatched_expected = [(i, q) for i, q in enumerate(expected_questions) if i not in matched_expected]
+        unmatched_actual = [(i, q) for i, q in enumerate(actual_questions) if i not in used_actual]
+
         # Match by relative position if we have similar numbers of unmatched questions
         if unmatched_expected and unmatched_actual:
-            position_matches = self._position_based_matching(
-                unmatched_expected, unmatched_actual
-            )
-            
+            position_matches = self._position_based_matching(unmatched_expected, unmatched_actual)
+
             for exp_idx, act_idx, confidence in position_matches:
-                matches.append(QuestionMatch(
-                    exp_idx, act_idx, expected_questions[exp_idx], 
-                    actual_questions[act_idx], MatchType.POSITION, confidence
-                ))
+                matches.append(
+                    QuestionMatch(
+                        exp_idx,
+                        act_idx,
+                        expected_questions[exp_idx],
+                        actual_questions[act_idx],
+                        MatchType.POSITION,
+                        confidence,
+                    )
+                )
                 used_actual.add(act_idx)
 
         return matches
-    
+
     def _text_similarity(self, text1: str, text2: str) -> float:
         """Calculate text similarity using a simple approach based on common words."""
         # Normalize texts
         words1 = set(text1.lower().strip().split())
         words2 = set(text2.lower().strip().split())
-        
+
         # Remove common stop words that don't add meaning
         stop_words = {
-            "the", "a", "an", "and", "or", "but", "in", "on", "at", "to", "for", "of", 
-            "with", "by", "is", "are", "was", "were", "what", "how", "when", "where", "why", "which"
+            "the",
+            "a",
+            "an",
+            "and",
+            "or",
+            "but",
+            "in",
+            "on",
+            "at",
+            "to",
+            "for",
+            "of",
+            "with",
+            "by",
+            "is",
+            "are",
+            "was",
+            "were",
+            "what",
+            "how",
+            "when",
+            "where",
+            "why",
+            "which",
         }
         words1 = words1 - stop_words
         words2 = words2 - stop_words
-        
+
         if not words1 or not words2:
             return 0.0
-        
+
         # Calculate Jaccard similarity
         intersection = len(words1 & words2)
         union = len(words1 | words2)
-        
+
         return intersection / union if union > 0 else 0.0
-    
+
     def _position_based_matching(
-        self, 
-        unmatched_expected: list[tuple[int, Question]], 
-        unmatched_actual: list[tuple[int, Question]]
+        self, unmatched_expected: list[tuple[int, Question]], unmatched_actual: list[tuple[int, Question]]
     ) -> list[tuple[int, int, float]]:
         """Match questions based on their relative positions."""
         matches: list[tuple[int, int, float]] = []
-        
+
         # Simple greedy approach: match questions in order of their positions
         min_len = min(len(unmatched_expected), len(unmatched_actual))
-        
+
         for i in range(min_len):
             exp_idx, exp_q = unmatched_expected[i]
             act_idx, act_q = unmatched_actual[i]
-            
+
             # Calculate confidence based on position alignment and question type similarity
             confidence = 0.4  # Base confidence for position matching
-            
+
             # Bonus if question types match
             if exp_q.type == act_q.type:
                 confidence += 0.2
-            
+
             # Small bonus for text similarity even if below threshold
             text_sim = self._text_similarity(exp_q.text, act_q.text)
             confidence += text_sim * 0.2
-            
+
             # Cap confidence at reasonable level for position-based matching
             confidence = min(confidence, 0.6)
-            
+
             matches.append((exp_idx, act_idx, confidence))
-        
+
         return matches
-    
+
     def _is_unique_number(self, number: str, questions: list[Question]) -> bool:
         """Check if a question number is unique within the question list."""
         if not number or number.isspace():
             return False
         count = sum(1 for q in questions if q.number == number)
         return count == 1
-    
+
     def _is_unique_id(self, id_val: str, questions: list[Question]) -> bool:
         """Check if a question ID is unique within the question list."""
         if not id_val or id_val.isspace():
             return False
         count = sum(1 for q in questions if q.id == id_val)
         return count == 1
-    

--- a/evals/evaluators/questionnaire_evaluators.py
+++ b/evals/evaluators/questionnaire_evaluators.py
@@ -30,7 +30,7 @@ class SectionPresenceEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
 
         # Use the section matcher to find section correspondences
         section_matches = self.section_matcher.match_sections(expected, actual)
-        
+
         true_positives = len(section_matches)
         total_expected = len(expected.sections)
         total_actual = len(actual.sections)
@@ -42,29 +42,30 @@ class SectionPresenceEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
         # Log mismatches for debugging
         matched_expected_indices = set(section_matches.keys())
         matched_actual_indices = set(section_matches.values())
-        
+
         missing_sections = [
             f"Section {i}: ({expected.sections[i].number}, '{expected.sections[i].title}')"
             for i in range(len(expected.sections))
             if i not in matched_expected_indices
         ]
-        
+
         extra_sections = [
             f"Section {i}: ({actual.sections[i].number}, '{actual.sections[i].title}')"
             for i in range(len(actual.sections))
             if i not in matched_actual_indices
         ]
-        
+
         if missing_sections:
             logger.warning(f"Missing sections ({len(missing_sections)}): {missing_sections}")
         if extra_sections:
             logger.warning(f"Unexpected sections ({len(extra_sections)}): {extra_sections}")
-            
+
         return {
             "section_presence_precision": precision,
             "section_presence_recall": recall,
             "section_presence_f1": f1,
         }
+
 
 class QuestionPresenceEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
     """Evaluator for checking that all expected questions are present."""
@@ -84,14 +85,14 @@ class QuestionPresenceEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
         expected_questions: list[Question] = []
         for section in expected.sections:
             expected_questions.extend(section.questions)
-        
+
         actual_questions: list[Question] = []
         for section in actual.sections:
             actual_questions.extend(section.questions)
 
         # Use the matcher to find question correspondences
         matches = self.matcher.match_questions(expected, actual)
-        
+
         true_positives = len(matches)
         total_expected = len(expected_questions)
         total_actual = len(actual_questions)
@@ -103,24 +104,24 @@ class QuestionPresenceEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
         # Log mismatches for debugging
         matched_expected_indices = {m.expected_idx for m in matches}
         matched_actual_indices = {m.actual_idx for m in matches}
-        
+
         missing_questions = [
             f"Q{i}: {expected_questions[i].number or 'no_num'} - {expected_questions[i].text[:50]}..."
             for i in range(len(expected_questions))
             if i not in matched_expected_indices
         ]
-        
+
         extra_questions = [
             f"Q{i}: {actual_questions[i].number or 'no_num'} - {actual_questions[i].text[:50]}..."
             for i in range(len(actual_questions))
             if i not in matched_actual_indices
         ]
-        
+
         if missing_questions:
             logger.warning(f"Missing questions ({len(missing_questions)}): {missing_questions[:5]}...")
         if extra_questions:
             logger.warning(f"Unexpected questions ({len(extra_questions)}): {extra_questions[:5]}...")
-            
+
         # Log match statistics
         match_types: dict[str, int] = {}
         for match in matches:
@@ -134,6 +135,7 @@ class QuestionPresenceEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
             "question_presence_f1": f1,
         }
 
+
 class QuestionTypeEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
     """Evaluator for checking that question types match the expected types."""
 
@@ -142,10 +144,7 @@ class QuestionTypeEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
         self.matcher: QuestionMatcher = QuestionMatcher()
 
     @override
-    def evaluate(
-        self,
-        ctx: EvaluatorContext[Path, Questionnaire, CaseMetadata]
-    ) -> dict[str, float]:
+    def evaluate(self, ctx: EvaluatorContext[Path, Questionnaire, CaseMetadata]) -> dict[str, float]:
         expected = ctx.expected_output
         assert expected is not None, "Expected output must not be None"
         actual: Questionnaire = ctx.output
@@ -154,18 +153,18 @@ class QuestionTypeEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
         expected_questions: list[Question] = []
         for section in expected.sections:
             expected_questions.extend(section.questions)
-        
+
         actual_questions: list[Question] = []
         for section in actual.sections:
             actual_questions.extend(section.questions)
 
         # Use the matcher to find question correspondences
         matches = self.matcher.match_questions(expected, actual)
-        
+
         # Count type matches among successfully matched questions
         type_matches = 0
         total_matches = len(matches)
-        
+
         for match in matches:
             if match.expected_question.type == match.actual_question.type:
                 type_matches += 1
@@ -177,11 +176,11 @@ class QuestionTypeEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
 
         # For precision: how many of the actual questions that were matched have correct types
         precision = type_matches / total_matches if total_matches else 0.0
-        
+
         # For recall: how many of the expected questions were matched with correct types
         total_expected = len(expected_questions)
         recall = type_matches / total_expected if total_expected else 0.0
-        
+
         f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
 
         return {
@@ -199,29 +198,26 @@ class OptionExtractionEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
         self.matcher: QuestionMatcher = QuestionMatcher()
 
     @override
-    def evaluate(
-        self,
-        ctx: EvaluatorContext[Path, Questionnaire, CaseMetadata]
-    ) -> dict[str, float]:
+    def evaluate(self, ctx: EvaluatorContext[Path, Questionnaire, CaseMetadata]) -> dict[str, float]:
         expected = ctx.expected_output
         assert expected is not None, "Expected output must not be None"
         actual: Questionnaire = ctx.output
 
         # Use the matcher to find question correspondences
         matches = self.matcher.match_questions(expected, actual)
-        
+
         # Filter matches to only include select questions and count option matches
         option_matches = 0
         total_select_matches = 0
-        
+
         for match in matches:
             exp_q = match.expected_question
             act_q = match.actual_question
-            
+
             # Only evaluate option extraction for select questions
             if isinstance(exp_q, SingleChoiceQuestion | MultipleChoiceQuestion):
                 total_select_matches += 1
-                
+
                 # Check if actual question is also a select question
                 if isinstance(act_q, SingleChoiceQuestion | MultipleChoiceQuestion):
                     # Compare options lists
@@ -229,17 +225,17 @@ class OptionExtractionEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
                         option_matches += 1
                     else:
                         # Format options more readably
-                        exp_opts = "\n    - " + "\n    - ".join(
-                            str(opt) for opt in exp_q.options
-                        ) if exp_q.options else "[]"
-                        act_opts = "\n    - " + "\n    - ".join(
-                            str(opt) for opt in act_q.options
-                        ) if act_q.options else "[]"
-                        
+                        exp_opts = (
+                            "\n    - " + "\n    - ".join(str(opt) for opt in exp_q.options) if exp_q.options else "[]"
+                        )
+                        act_opts = (
+                            "\n    - " + "\n    - ".join(str(opt) for opt in act_q.options) if act_q.options else "[]"
+                        )
+
                         logger.warning(
-                            f"Option mismatch for {exp_q.number or exp_q.id}:\n" +
-                            f"Expected options:{exp_opts}\n" +
-                            f"Actual options:{act_opts}"
+                            f"Option mismatch for {exp_q.number or exp_q.id}:\n"
+                            + f"Expected options:{exp_opts}\n"
+                            + f"Actual options:{act_opts}"
                         )
                 else:
                     logger.warning(
@@ -249,14 +245,15 @@ class OptionExtractionEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
 
         # Calculate metrics based on successfully matched select questions
         precision = option_matches / total_select_matches if total_select_matches else 0.0
-        
+
         # For recall, count all expected select questions
         total_expected_select = sum(
-            1 for section in expected.sections
+            1
+            for section in expected.sections
             for question in section.questions
             if isinstance(question, SingleChoiceQuestion | MultipleChoiceQuestion)
         )
-        
+
         recall = option_matches / total_expected_select if total_expected_select else 0.0
         f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
 
@@ -275,10 +272,7 @@ class QuestionTextEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
         self.matcher: QuestionMatcher = QuestionMatcher()
 
     @override
-    def evaluate(
-        self,
-        ctx: EvaluatorContext[Path, Questionnaire, CaseMetadata]
-    ) -> dict[str, float]:
+    def evaluate(self, ctx: EvaluatorContext[Path, Questionnaire, CaseMetadata]) -> dict[str, float]:
         """Compute precision, recall, and F1 for exact question text matches."""
         expected = ctx.expected_output
         assert expected is not None, "Expected output must not be None"
@@ -288,18 +282,18 @@ class QuestionTextEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
         expected_questions: list[Question] = []
         for section in expected.sections:
             expected_questions.extend(section.questions)
-        
+
         actual_questions: list[Question] = []
         for section in actual.sections:
             actual_questions.extend(section.questions)
 
         # Use the matcher to find question correspondences
         matches = self.matcher.match_questions(expected, actual)
-        
+
         # Count exact text matches among successfully matched questions
         text_matches = 0
         total_matches = len(matches)
-        
+
         for match in matches:
             if match.expected_question.text == match.actual_question.text:
                 text_matches += 1
@@ -312,11 +306,11 @@ class QuestionTextEvaluator(Evaluator[Path, Questionnaire, CaseMetadata]):
 
         # For precision: how many of the actual questions that were matched have exact text
         precision = text_matches / total_matches if total_matches else 0.0
-        
+
         # For recall: how many of the expected questions were matched with exact text
         total_expected = len(expected_questions)
         recall = text_matches / total_expected if total_expected else 0.0
-        
+
         f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
 
         return {
@@ -335,10 +329,7 @@ class QuestionSectionGroupingEvaluator(Evaluator[Path, Questionnaire, CaseMetada
         self.section_matcher: SectionMatcher = SectionMatcher()
 
     @override
-    def evaluate(
-        self,
-        ctx: EvaluatorContext[Path, Questionnaire, CaseMetadata]
-    ) -> dict[str, float]:
+    def evaluate(self, ctx: EvaluatorContext[Path, Questionnaire, CaseMetadata]) -> dict[str, float]:
         """Compute precision, recall, and F1 for correct question section grouping."""
         expected = ctx.expected_output
         assert expected is not None, "Expected output must not be None"
@@ -346,7 +337,7 @@ class QuestionSectionGroupingEvaluator(Evaluator[Path, Questionnaire, CaseMetada
 
         # First, match sections between expected and actual questionnaires
         section_matches = self.section_matcher.match_sections(expected, actual)
-        
+
         # Build mappings from question flat index to matched section index
         expected_question_to_section_idx: dict[int, int] = {}
         flat_idx = 0
@@ -364,20 +355,20 @@ class QuestionSectionGroupingEvaluator(Evaluator[Path, Questionnaire, CaseMetada
 
         # Use the question matcher to find question correspondences
         matches = self.matcher.match_questions(expected, actual)
-        
+
         # Count correct section groupings among successfully matched questions
         correct_groupings = 0
         total_matches = len(matches)
-        
+
         for match in matches:
             # Get section indices for both questions
             expected_section_idx = expected_question_to_section_idx.get(match.expected_idx)
             actual_section_idx = actual_question_to_section_idx.get(match.actual_idx)
-            
+
             if expected_section_idx is not None and actual_section_idx is not None:
                 # Check if the actual section matches the expected section
                 expected_matched_section_idx = section_matches.get(expected_section_idx)
-                
+
                 if expected_matched_section_idx == actual_section_idx:
                     correct_groupings += 1
                 else:
@@ -385,7 +376,7 @@ class QuestionSectionGroupingEvaluator(Evaluator[Path, Questionnaire, CaseMetada
                     question_id = match.expected_question.number or match.expected_question.id
                     exp_section = expected.sections[expected_section_idx]
                     act_section = actual.sections[actual_section_idx]
-                    
+
                     if expected_matched_section_idx is not None:
                         expected_matched_section = actual.sections[expected_matched_section_idx]
                         logger.warning(
@@ -403,17 +394,15 @@ class QuestionSectionGroupingEvaluator(Evaluator[Path, Questionnaire, CaseMetada
                         )
             else:
                 question_id = match.expected_question.number or match.expected_question.id
-                logger.warning(
-                    f"Could not determine section for question {question_id}"
-                )
+                logger.warning(f"Could not determine section for question {question_id}")
 
         # For precision: how many of the matched questions are in the correct section
         precision = correct_groupings / total_matches if total_matches else 0.0
-        
+
         # For recall: how many of the expected questions were matched and placed in correct sections
         total_expected_questions = sum(len(section.questions) for section in expected.sections)
         recall = correct_groupings / total_expected_questions if total_expected_questions else 0.0
-        
+
         f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
 
         return {

--- a/evals/evaluators/section_matcher.py
+++ b/evals/evaluators/section_matcher.py
@@ -8,6 +8,7 @@ from survaize.model.questionnaire import Questionnaire, Section
 @dataclass
 class SectionMatch:
     """Represents a matched section pair."""
+
     expected_idx: int
     actual_idx: int
     expected_section: Section
@@ -18,7 +19,7 @@ class SectionMatch:
 
 class SectionMatcher:
     """Simple matcher for sections using number, title, and position."""
-    
+
     def match_sections(self, expected: Questionnaire, actual: Questionnaire) -> dict[int, int]:
         """
         Match sections between questionnaires.
@@ -26,48 +27,54 @@ class SectionMatcher:
         """
         expected_sections = expected.sections
         actual_sections = actual.sections
-        
+
         section_matches: dict[int, int] = {}
         used_actual: set[int] = set()
-        
+
         # Level 1: Exact number and title match
         for exp_idx, exp_section in enumerate(expected_sections):
             for act_idx, act_section in enumerate(actual_sections):
-                if (act_idx not in used_actual and
-                    exp_section.number == act_section.number and
-                    exp_section.title == act_section.title):
+                if (
+                    act_idx not in used_actual
+                    and exp_section.number == act_section.number
+                    and exp_section.title == act_section.title
+                ):
                     section_matches[exp_idx] = act_idx
                     used_actual.add(act_idx)
                     break
-        
+
         # Level 2: Number match only (if unique)
         for exp_idx, exp_section in enumerate(expected_sections):
-            if (exp_idx not in section_matches and
-                sum(1 for s in expected_sections if s.number == exp_section.number) == 1):
+            if (
+                exp_idx not in section_matches
+                and sum(1 for s in expected_sections if s.number == exp_section.number) == 1
+            ):
                 for act_idx, act_section in enumerate(actual_sections):
-                    if (act_idx not in used_actual and
-                        act_section.number == exp_section.number and
-                        sum(1 for s in actual_sections if s.number == act_section.number) == 1):
+                    if (
+                        act_idx not in used_actual
+                        and act_section.number == exp_section.number
+                        and sum(1 for s in actual_sections if s.number == act_section.number) == 1
+                    ):
                         section_matches[exp_idx] = act_idx
                         used_actual.add(act_idx)
                         break
-        
+
         # Level 3: Title match only (if reasonably unique)
         for exp_idx, exp_section in enumerate(expected_sections):
             if exp_idx not in section_matches:
                 for act_idx, act_section in enumerate(actual_sections):
-                    if (act_idx not in used_actual and
-                        exp_section.title.strip().lower() == act_section.title.strip().lower()):
+                    if (
+                        act_idx not in used_actual
+                        and exp_section.title.strip().lower() == act_section.title.strip().lower()
+                    ):
                         section_matches[exp_idx] = act_idx
                         used_actual.add(act_idx)
                         break
-        
+
         # Level 4: Position-based fallback
         for exp_idx, _ in enumerate(expected_sections):
-            if (exp_idx not in section_matches and
-                exp_idx < len(actual_sections) and 
-                exp_idx not in used_actual):
+            if exp_idx not in section_matches and exp_idx < len(actual_sections) and exp_idx not in used_actual:
                 section_matches[exp_idx] = exp_idx
                 used_actual.add(exp_idx)
-        
+
         return section_matches

--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -13,14 +13,14 @@ load_dotenv()
 config = create_llm_config_from_env()
 
 logfire.configure(
-    send_to_logfire='if-token-present',  
-    environment='development',  
-    service_name='evals',  
+    send_to_logfire="if-token-present",
+    environment="development",
+    service_name="evals",
 )
 logfire.instrument_openai()
 
-async def convert_questionnaire(pdf_path: Path) -> Questionnaire:
 
+async def convert_questionnaire(pdf_path: Path) -> Questionnaire:
     interpreter = AIQuestionnaireInterpreter(llm_config=config, sleep_between_pages_seconds=10)
     pdf_reader = PDFReader(interpreter)
     with open(pdf_path, "rb") as f:
@@ -29,7 +29,6 @@ async def convert_questionnaire(pdf_path: Path) -> Questionnaire:
 
 
 def run_evals():
-
     dataset = load_dataset()
 
     report = dataset.evaluate_sync(task=convert_questionnaire, max_concurrency=1)


### PR DESCRIPTION
## Summary
- include the `evals` directory in lint checks
- format the evaluation scripts to satisfy ruff

## Testing
- `uv run python devtools/lint.py`

------
https://chatgpt.com/codex/tasks/task_e_68745e4c44e08320bc2e03df23d08fa4